### PR TITLE
fix: prevent crash when try to delete new questions

### DIFF
--- a/packages/web/src/features/quizz/contexts/quizz-editor-context.tsx
+++ b/packages/web/src/features/quizz/contexts/quizz-editor-context.tsx
@@ -58,7 +58,7 @@ export const QuizzEditorProvider = ({
       : [defaultQuestion()],
   )
   const [currentIndex, setCurrentIndex] = useState(0)
-  const currentQuestion = questions[currentIndex]
+  const currentQuestion = questions[currentIndex] ?? defaultQuestion()
 
   const addQuestion = () => {
     setQuestions((prev) => [...prev, defaultQuestion()])


### PR DESCRIPTION
> This description was generated with AI

Deleting a question in the quizz editor caused a `Cannot read properties of undefined (reading 'question')` crash. This happened when the deleted question was empty (or when the current selection index pointed to the deleted question).
Closes #96 

### Root cause

`currentQuestion` in `QuizzEditorProvider` was derived as:

```tsx
const currentQuestion = questions[currentIndex]
```

When `removeQuestion` runs, it batches two state updates:

```tsx
setQuestions(next)          // shorter array
setCurrentIndex(nextIndex)  // adjusted index
```

During the transitional re-render, `currentIndex` could point past the end of the now-shorter `questions` array, making `questions[currentIndex]` return `undefined`. Consumer components (`QuestionEditorTitle`, `QuestionEditorAnswers`, `QuestionEditorConfig`, `QuestionEditorMedia`) then crashed when accessing properties like `currentQuestion.question`.

### Fix

Added a nullish fallback at the single source of truth in the context:

```tsx
const currentQuestion = questions[currentIndex] ?? defaultQuestion()
```

This guarantees `currentQuestion` is never `undefined`. If `currentIndex` is transiently out of bounds, a default empty question is used for that render, and the next render with the corrected index shows the proper question.