### PR TITLE
feat: add Vietnamese language support and update language switcher

### DIFF
--- a/packages/web/src/components/LanguageSwitcher.tsx
+++ b/packages/web/src/components/LanguageSwitcher.tsx
@@ -15,6 +15,7 @@ const LANGUAGES = [
   { code: "fr", label: "common:language.fr" },
   { code: "it", label: "common:language.it" },
   { code: "ja", label: "common:language.ja" },
+  { code: "vi", label: "common:language.vi" },
 ]
 
 const LanguageSwitcher = () => {

--- a/packages/web/src/features/game/components/AnswerButton.tsx
+++ b/packages/web/src/features/game/components/AnswerButton.tsx
@@ -30,7 +30,7 @@ const AnswerButton = ({
       <span className="flex size-5 shrink-0 items-center justify-center rounded bg-black/20 text-sm font-bold sm:size-7 sm:rounded-md md:size-8 md:text-base">
         {label}
       </span>
-      <p className="w-full flex-1 text-sm break-all drop-shadow-md md:text-lg">
+      <p className="break-word w-full flex-1 text-sm drop-shadow-md md:text-lg">
         {children}
       </p>
       {correct !== undefined && (

--- a/packages/web/src/features/game/components/states/Result.tsx
+++ b/packages/web/src/features/game/components/states/Result.tsx
@@ -21,7 +21,7 @@ const Result = ({
     2: "game:rank.2",
     3: "game:rank.3",
   }
-  const rankKey = rankKeyMap[rank] ?? "game.rank.other"
+  const rankKey = rankKeyMap[rank] ?? "game:rank.other"
 
   const [sfxResults] = useSound(SFX.RESULTS_SOUND, {
     volume: 0.2,

--- a/packages/web/src/features/game/components/states/Result.tsx
+++ b/packages/web/src/features/game/components/states/Result.tsx
@@ -21,7 +21,7 @@ const Result = ({
     2: "game:rank.2",
     3: "game:rank.3",
   }
-  const rankKey = rankKeyMap[rank] ?? "rank.other"
+  const rankKey = rankKeyMap[rank] ?? "game.rank.other"
 
   const [sfxResults] = useSound(SFX.RESULTS_SOUND, {
     volume: 0.2,

--- a/packages/web/src/features/game/components/states/Room.tsx
+++ b/packages/web/src/features/game/components/states/Room.tsx
@@ -66,7 +66,7 @@ const Room = ({ data: { text, inviteCode } }: Props) => {
           <div className="flex flex-col items-center justify-center rounded-xl bg-white px-6 py-4 md:flex-row">
             <div>
               <p className="text-2xl font-bold">{t("game:joinInstruction")}</p>
-              <p className="max-w-64 text-lg font-extrabold break-all">
+              <p className="break-word max-w-64 text-lg font-extrabold">
                 {webUrl}
               </p>
             </div>

--- a/packages/web/src/locales/de/common.json
+++ b/packages/web/src/locales/de/common.json
@@ -10,7 +10,8 @@
     "es": "Español - Spanisch",
     "fr": "Français - Französisch",
     "it": "Italiano - Italienisch",
-    "ja": "日本語 - Japanisch"
+    "ja": "日本語 - Japanisch",
+    "vi": "Tiếng Việt - Vietnamesisch"
   },
   "loading": "Laden...",
   "next": "Weiter",

--- a/packages/web/src/locales/en/common.json
+++ b/packages/web/src/locales/en/common.json
@@ -10,7 +10,8 @@
     "es": "Español - Spanish",
     "fr": "Français - French",
     "it": "Italiano - Italian",
-    "ja": "日本語 - Japanese"
+    "ja": "日本語 - Japanese",
+    "vi": "Tiếng Việt - Vietnamese"
   },
   "loading": "Loading...",
   "next": "Next",

--- a/packages/web/src/locales/es/common.json
+++ b/packages/web/src/locales/es/common.json
@@ -10,7 +10,8 @@
     "es": "Español - Español",
     "fr": "Français - Francés",
     "it": "Italiano - Italiano",
-    "ja": "日本語 - Japonés"
+    "ja": "日本語 - Japonés",
+    "vi": "Tiếng Việt - Vietnamita"
   },
   "loading": "Cargando...",
   "next": "Siguiente",

--- a/packages/web/src/locales/fr/common.json
+++ b/packages/web/src/locales/fr/common.json
@@ -10,7 +10,8 @@
     "es": "Español - Espagnol",
     "fr": "Français - Français",
     "it": "Italiano - Italien",
-    "ja": "日本語 - Japonais"
+    "ja": "日本語 - Japonais",
+    "vi": "Tiếng Việt - Vietnamien"
   },
   "loading": "Chargement...",
   "next": "Suivant",

--- a/packages/web/src/locales/it/common.json
+++ b/packages/web/src/locales/it/common.json
@@ -10,7 +10,8 @@
     "es": "Español - Spagnolo",
     "fr": "Français - Francese",
     "it": "Italiano - Italiano",
-    "ja": "日本語 - Giapponese"
+    "ja": "日本語 - Giapponese",
+    "vi": "Tiếng Việt - Vietnamita"
   },
   "loading": "Caricamento...",
   "next": "Avanti",

--- a/packages/web/src/locales/ja/common.json
+++ b/packages/web/src/locales/ja/common.json
@@ -10,7 +10,8 @@
     "es": "Español - スペイン語",
     "fr": "Français - フランス語",
     "it": "Italiano - イタリア語",
-    "ja": "日本語 - 日本語"
+    "ja": "日本語 - 日本語",
+    "vi": "Tiếng Việt - ベトナム語"
   },
   "loading": "読み込み中...",
   "next": "次へ",

--- a/packages/web/src/locales/vi/common.json
+++ b/packages/web/src/locales/vi/common.json
@@ -1,0 +1,22 @@
+{
+  "cancel": "Hủy",
+  "confirm": "Xác nhận",
+  "connecting": "Đang kết nối...",
+  "delete": "Xóa",
+  "exit": "Thoát",
+  "language": {
+    "de": "Deutsch - Tiếng Đức",
+    "en": "English - Tiếng Anh",
+    "es": "Español - Tiếng Tây Ban Nha",
+    "fr": "Français - Tiếng Pháp",
+    "it": "Italiano - Tiếng Ý",
+    "ja": "日本語 - Tiếng Nhật",
+    "vi": "Tiếng Việt - Vietnamese"
+  },
+  "loading": "Đang tải...",
+  "next": "Tiếp",
+  "save": "Lưu",
+  "seconds": "giây",
+  "skip": "Bỏ qua",
+  "submit": "Gửi"
+}

--- a/packages/web/src/locales/vi/errors.json
+++ b/packages/web/src/locales/vi/errors.json
@@ -1,0 +1,45 @@
+{
+  "auth": {
+    "invalidInviteCode": "Mã tham dự không hợp lệ",
+    "usernameTooLong": "Tên người dùng không được vượt quá 20 ký tự",
+    "usernameTooShort": "Tên người dùng không được ngắn hơn 4 ký tự"
+  },
+  "game": {
+    "expired": "Trò chơi đã hết hạn",
+    "kickedByManager": "Bạn đã bị quản trị viên mời ra khỏi phòng",
+    "managerAlreadyConnected": "Quản trị viên đã kết nối",
+    "managerDisconnected": "Quản trị viên đã ngắt kết nối",
+    "noPlayersConnected": "Không có người chơi nào kết nối",
+    "managerCannotJoin": "Bạn không thể tham gia trò chơi của chính mình",
+    "notFound": "Không tìm thấy trò chơi",
+    "playerAlreadyConnected": "Người chơi đã kết nối"
+  },
+  "manager": {
+    "failedToReadConfig": "Không đọc được cấu hình trò chơi",
+    "invalidPassword": "Mật khẩu không hợp lệ",
+    "passwordNotConfigured": "Mật khẩu quản trị viên chưa được cấu hình"
+  },
+  "notFound": {
+    "back": "Về trang chủ",
+    "description": "Trang bạn đang tìm không tồn tại.",
+    "title": "Không tìm thấy trang"
+  },
+  "quizz": {
+    "answerEmpty": "Đáp án không được để trống",
+    "failedToDelete": "Xóa trò chơi thất bại",
+    "failedToSave": "Trò chơi chưa hoàn chỉnh, hãy đảm bảo mọi câu hỏi đều có tiêu đề và ít nhất một đáp án đúng",
+    "failedToUpdate": "Cập nhật trò chơi thất bại",
+    "invalidMediaUrl": "URL media phải là một URL hợp lệ",
+    "noQuestions": "Trò chơi phải có ít nhất một câu hỏi",
+    "notFound": "Không tìm thấy trò chơi",
+    "questionEmpty": "Câu hỏi không được để trống",
+    "subjectEmpty": "Chủ đề không được để trống",
+    "tooFewAnswers": "Một câu hỏi phải có ít nhất 2 câu trả lời",
+    "tooManyAnswers": "Một câu hỏi không được có quá 4 câu trả lời"
+  },
+  "route": {
+    "back": "Về trang chủ",
+    "description": "Đã xảy ra lỗi không mong muốn. Vui lòng thử lại.",
+    "title": "Đã có lỗi xảy ra"
+  }
+}

--- a/packages/web/src/locales/vi/game.json
+++ b/packages/web/src/locales/vi/game.json
@@ -1,0 +1,30 @@
+{
+  "correct": "Chính xác!",
+  "gamePinLabel": "Mã PIN trò chơi:",
+  "hud": {
+    "answers": "Câu trả lời",
+    "time": "Thời gian"
+  },
+  "joinInstruction": "Tham gia trò chơi tại",
+  "leaderboard": "Bảng xếp hạng",
+  "pinLabel": "Mã PIN",
+  "reconnect": "Kết nối lại",
+  "reconnectTitle": "Bạn đang ở trong một trò chơi",
+  "playersJoined": "Người chơi đã tham gia: ",
+  "questionPrefix": "Câu hỏi #",
+  "rank": {
+    "1": "Top 1",
+    "2": "Top 2",
+    "3": "Top 3",
+    "other": "Top {{rank}}"
+  },
+  "rankSuffix": "",
+  "resultBehind": ", sau ",
+  "resultTop": "Bạn xếp ",
+  "startGame": "Bắt đầu trò chơi",
+  "usernamePlaceholder": "Nhập tên người dùng",
+  "waitingForAnswers": "Đang chờ người chơi trả lời",
+  "waitingForPlayers": "Đang chờ người chơi",
+  "wrong": "Sai rồi",
+  "confirm": "Xác nhận"
+}

--- a/packages/web/src/locales/vi/manager.json
+++ b/packages/web/src/locales/vi/manager.json
@@ -1,0 +1,45 @@
+{
+  "configurationsTitle": "Cấu hình",
+  "logout": "Đăng xuất",
+  "passwordPlaceholder": "Mật khẩu",
+  "quizz": {
+    "create": "Tạo trò chơi",
+    "delete": "Xóa trò chơi",
+    "deleteConfirm": "Bạn có chắc muốn xóa \"{{name}}\"? Trò chơi này sẽ bị xóa vĩnh viễn.",
+    "deleted": "Đã xóa trò chơi",
+    "export": "Xuất trò chơi dạng JSON",
+    "import": "Nhập trò chơi từ JSON",
+    "none": "Chưa có trò chơi nào",
+    "notFound": "Không tìm thấy trò chơi",
+    "pleaseCreate": "Vui lòng tạo trò chơi trước",
+    "pleaseSelect": "Vui lòng chọn một trò chơi",
+    "startGame": "Bắt đầu trò chơi"
+  },
+  "result": {
+    "delete": "Xóa kết quả",
+    "deleteConfirm": "Xóa kết quả của \"{{name}}\"? Kết quả này sẽ bị xóa vĩnh viễn.",
+    "deleted": "Đã xóa kết quả",
+    "noAnswer": "Không có câu trả lời",
+    "none": "Chưa có kết quả, hoàn thành một trò chơi để xem báo cáo tại đây",
+    "paginationOf": " / ",
+    "stats": {
+      "correctAnswers": "Câu trả lời đúng",
+      "playersAnswered": "Người chơi đã trả lời"
+    },
+    "table": {
+      "answered": "Đã trả lời",
+      "correct": " Đúng",
+      "correctIncorrect": "Đúng / Sai",
+      "incorrect": " Sai",
+      "player": "Người chơi",
+      "points": "Điểm"
+    },
+    "playerCount": "{{count}} người chơi",
+    "timeLimitSuffix": "s giới hạn thời gian"
+  },
+  "tabs": {
+    "play": "Trò chơi",
+    "quizz": "Cấu hình",
+    "results": "Kết quả"
+  }
+}

--- a/packages/web/src/locales/vi/quizz.json
+++ b/packages/web/src/locales/vi/quizz.json
@@ -1,0 +1,48 @@
+{
+  "addAnswerPlaceholder": "Thêm câu trả lời...",
+  "addQuestion": "Thêm câu hỏi",
+  "answersCountSuffix": " câu trả lời",
+  "deleteQuestion": "Xóa câu hỏi",
+  "noQuestionYet": "Chưa có câu hỏi",
+  "question": {
+    "addMediaHint": "Thêm ảnh, video hoặc âm thanh vào câu hỏi",
+    "config": {
+      "answerTime": "Thời gian trả lời",
+      "answerTimeHint": "Thời gian người chơi có để trả lời",
+      "noTimeLimit": "Không giới hạn thời gian",
+      "noTimeLimitHint": "Điểm được tính theo thứ tự trả lời. Không có giới hạn thời gian để trả lời.",
+      "questionDisplay": "Hiển thị câu hỏi",
+      "questionDisplayHint": "Thời gian trước khi hiện câu trả lời",
+      "timings": "Thời gian",
+      "answerMode": "Chế độ trả lời",
+      "scoring": "Tính điểm",
+      "maxPoints": "Điểm tối đa",
+      "maxPointsHint": "Điểm tối đa khi trả lời đúng",
+      "penalty": "Phạt",
+      "penaltyHint": "Điểm bị trừ khi chọn đáp án sai (tổng điểm không dưới 0)",
+      "scoringMode": "Chế độ tính điểm",
+      "scoringMode.strict": "Nghiêm ngặt",
+      "scoringMode.balanced": "Cân bằng",
+      "scoringMode.lenient": "Dễ dàng",
+      "scoringModeHint.strict": "Điểm đầy đủ chỉ khi chọn đủ đáp án đúng và không chọn đáp án sai",
+      "scoringModeHint.balanced": "Điểm một phần: đáp án đúng, bị phạt đáp án sai",
+      "scoringModeHint.lenient": "Điểm theo từng đáp án đúng, không phạt đáp án sai"
+    },
+    "deleteQuestion": "Xóa câu hỏi",
+    "deleteQuestionConfirm": "Bạn có chắc muốn xóa câu hỏi này?",
+    "media": {
+      "audio": "Âm thanh",
+      "image": "Hình ảnh",
+      "video": "Video"
+    },
+    "mediaUrlPlaceholder": "Nhập URL...",
+    "placeholder": "Nhập câu hỏi của bạn..."
+  },
+  "quizzSaved": "Đã lưu trò chơi thành công",
+  "quizzUpdated": "Đã cập nhật trò chơi thành công",
+  "questionType": {
+    "single": "Chọn một đáp án",
+    "multi": "Chọn nhiều đáp án"
+  },
+  "titleQuizzPlaceholder": "Tiêu đề trò chơi..."
+}


### PR DESCRIPTION
## Summary
- Add full Vietnamese locale under `packages/web/src/locales/vi/` (`common`, `game`, `errors`, `manager`, `quizz`)
- Register `vi` in `LanguageSwitcher`
- Add `language.vi` label to all existing `common.json` locales (en/de/es/fr/it/ja/vi)
## Context
Razzia already supports multiple languages via i18next + locale JSON. This MR adds Vietnamese so users can select **VI** in the language switcher without changing i18n bootstrap (locales are loaded via glob).
