### PR TITLE
Normalise line endings to LF via .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,15 @@
+# Every text file in this repository is stored with LF.
+#
+# Without this, a Windows checkout with the default core.autocrlf=true
+# rewrites them all to CRLF on clone. `pnpm lint` then fails with
+# @stylistic(linebreak-style) on every line of every file, and any
+# format-on-save produces a whole-repo diff, which makes a first
+# contribution from Windows effectively impossible.
+* text=auto eol=lf
+
+# Binary assets, never normalised.
+*.png binary
+*.jpg binary
+*.mp3 binary
+*.woff2 binary
+*.svg text eol=lf


### PR DESCRIPTION
Every text file in the repository is already stored with LF, but nothing enforces it on checkout. On Windows, where `core.autocrlf` defaults to `true`, cloning rewrites all of them to CRLF.

The effect is not subtle. On a fresh clone of `main` on Windows:

```
$ pnpm lint 2>&1 | grep -c linebreak-style
1626
```

`pnpm format` fails on the whole tree at the same time. Since `@stylistic/linebreak-style` is set to `"unix"` in `oxlint.config.ts`, every line of every file is reported, and a first-time contributor on Windows starts with 1626 errors and no obvious cause — the files look fine in an editor.

Format-on-save then makes it worse, because it produces a whole-repository diff that buries whatever change they actually came to make.

`* text=auto eol=lf` fixes it at the source: git normalises on checkout regardless of the user's `core.autocrlf`. Binary assets are marked so they are never touched.

**Nothing in the repository's content changes.** Existing checkouts need one refresh to pick it up:

```
git rm --cached -r .
git reset --hard
```

I hit this setting the repo up on Windows and it cost a while to diagnose, so it seemed worth sending upstream rather than carrying locally.
