### PR TITLE
Stop answer colours and letters wrapping past the fourth

### DIFF
--- a/packages/web/src/features/manager/components/ResultModal/ResultModalAnswers.tsx
+++ b/packages/web/src/features/manager/components/ResultModal/ResultModalAnswers.tsx
@@ -64,8 +64,12 @@ const ResultModalAnswers = () => {
         pa.answerIds?.includes(ai),
       ).length,
       isCorrect: questionResult.solutions.includes(ai),
-      color: ANSWERS_COLORS[ai % 4],
-      answerLabel: ANSWERS_LABELS[ai % 4],
+      // Wrapping with `% 4` would give a fifth answer the first answer's
+      // colour and letter, so two different options would look identical
+      // in the results. Falling back to null renders the neutral row the
+      // "no answer" case already uses.
+      color: ai < ANSWERS_COLORS.length ? ANSWERS_COLORS[ai] : null,
+      answerLabel: ai < ANSWERS_LABELS.length ? ANSWERS_LABELS[ai] : null,
     })),
     {
       label: t("manager:result.noAnswer"),

--- a/packages/web/src/features/manager/components/ResultModal/ResultModalTable.tsx
+++ b/packages/web/src/features/manager/components/ResultModal/ResultModalTable.tsx
@@ -43,11 +43,15 @@ const ResultModalTable = () => {
                         key={id}
                         className={clsx(
                           "inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs text-white",
-                          ANSWERS_COLORS[id % 4],
+                          id < ANSWERS_COLORS.length
+                            ? ANSWERS_COLORS[id]
+                            : "bg-gray-500",
                         )}
                       >
                         <span className="font-bold">
-                          {ANSWERS_LABELS[id % 4]}
+                          {id < ANSWERS_LABELS.length
+                            ? ANSWERS_LABELS[id]
+                            : id + 1}
                         </span>
                         <span className="max-w-30 truncate">
                           {questionResult.answers[id]}


### PR DESCRIPTION
`ResultModalAnswers` and `ResultModalTable` index `ANSWERS_COLORS` and `ANSWERS_LABELS` with `% 4`:

```ts
color: ANSWERS_COLORS[ai % 4],
answerLabel: ANSWERS_LABELS[ai % 4],
```

Both arrays have exactly four entries, so a fifth answer would wrap to index 0 and be drawn with the **first answer's colour and the letter "A"** — two different options presented identically to a teacher reading the distribution.

**This cannot happen today.** The quiz validator caps `answers` at four, so the index never exceeds 3 and the modulo is a no-op. I am not reporting a live bug.

What it is, is a landmine. Raising that cap is otherwise a small change — the colour palette, the labels, the answer grid — and this would turn into a silent rendering fault in the results view that *looks correct*, so it would not be the thing anyone thinks to check.

Both call sites now compare against the array length and fall back rather than wrap:

- the answers view reuses the neutral row it already renders for the "no answer" case
- the table falls back to a grey chip with the 1-based index as its label

No behaviour change for any quiz that can exist under the current validator. `pnpm lint`, `pnpm format` and `pnpm build` pass.

Happy to close this if you would rather keep the modulo as a deliberate clamp — in which case it might be worth a comment saying so, since it currently reads as an oversight.
