### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,4 +139,4 @@ For bug reports or feature requests, please [create an issue](https://github.com
 
 ## ⭐ Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Ralex91/Razzia&type=date&logscale=&legend=bottom-right)](https://www.star-history.com/#Ralex91/Razzia&type=date&logscale=&legend=bottom-right)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Ralex91/Razzia&type=date&logscale=&legend=bottom-right)](https://star-history.dera.page/#Ralex91/Razzia&type=date&logscale=&legend=bottom-right)


### PR DESCRIPTION
The star history chart in the README is currently broken because the previous service relies on GitHub's stargazer API, which is now restricted. This PR points the chart to star-history.dera.page, a fork that uses another data source requiring no API token, so the chart displays correctly again.