### PR TITLE
feat: upload and reuse media (images + audio) in the quiz editor

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,6 +4,7 @@
 
 # gitignored / secrets - must never enter the build context
 config
+media
 .env
 .secrets
 release.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   checks:
-    name: Lint & Format
+    name: Lint, Format & Test
     runs-on: ubuntu-latest
     if: github.actor != 'dependabot[bot]' || contains(github.event.pull_request.labels.*.name, 'javascript')
     steps:
@@ -31,3 +31,6 @@ jobs:
 
       - name: Lint
         run: pnpm lint
+
+      - name: Test
+        run: pnpm test

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /node_modules
 /config
+/media
 .env
 .secrets
 release.json

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Or using Docker directly:
 docker run -d \
   -p 3000:3000 \
   -v ./config:/app/config \
+  -v ./media:/app/media \
   ralex91/razzia:latest
 ```
 
@@ -61,6 +62,7 @@ The image is also published on the GitHub Container Registry, if you prefer usin
 docker run -d \
   -p 3000:3000 \
   -v ./config:/app/config \
+  -v ./media:/app/media \
   ghcr.io/ralex91/razzia:latest
 ```
 
@@ -72,6 +74,9 @@ The `-v ./config:/app/config` option mounts a local `config` folder to persist y
 - Easily backup your quizzes and game configuration
 
 The folder will be created automatically on first run with an example quiz to get you started.
+
+**Media Volume:**
+The `-v ./media:/app/media` option mounts a local `media` folder where uploaded question media is stored, separate from your `config`. It persists across container restarts and updates, and can be backed up independently. Uploads accept images and audio up to 20 MB each; video is attached by external URL instead.
 
 The application will be available at http://localhost:3000
 

--- a/compose.yml
+++ b/compose.yml
@@ -5,3 +5,4 @@ services:
       - "3000:3000"
     volumes:
       - ./config:/app/config
+      - ./media:/app/media

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -4,12 +4,28 @@ server {
     root /app/web;
     index index.html;
 
+    client_max_body_size 20m;
+
     location / {
         try_files $uri $uri/ /index.html;
     }
 
     location /branding/ {
         alias /app/config/branding/;
+    }
+
+    location /media/ {
+        alias /app/media/;
+        add_header X-Content-Type-Options nosniff;
+    }
+
+    location /api/ {
+        proxy_pass http://127.0.0.1:3001;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
     }
 
     location /ws {

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -15,7 +15,7 @@ stderr_logfile_maxbytes=0
 
 [program:socket]
 command=node /app/socket/index.cjs
-environment=NODE_ENV="production",CONFIG_PATH="/app/config"
+environment=NODE_ENV="production",CONFIG_PATH="/app/config",MEDIA_PATH="/app/media"
 autostart=true
 autorestart=true
 stdout_logfile=/dev/stdout

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,3 +17,9 @@ Options:
 - `managerPassword`: The master password for accessing the manager interface. **Must be changed from the default `"PASSWORD"` value**, otherwise manager access is blocked.
 
 See also: [Quiz Configuration](quiz.md) and [Custom Branding](branding.md), also stored in the `config` folder.
+
+## Media Storage (`media` folder)
+
+Uploaded question media is stored in a dedicated `media` folder, mounted as its own Docker volume (`./media:/app/media`) and kept separate from `config`. It persists across restarts and updates and can be backed up on its own. Uploads accept images (PNG, JPEG, WebP, GIF) and audio (MP3, OGG, WAV) up to 20 MB each; video is not uploadable and is attached by external URL instead.
+
+The volume is a single flat, unmanaged store shared across all quizzes — files are never deduplicated and deleting a quiz never deletes its media, so with audio now allowed (larger files than images) plan for the folder to grow and prune it manually if needed.

--- a/docs/quiz.md
+++ b/docs/quiz.md
@@ -52,7 +52,7 @@ Quiz Options:
   - `answers`: Array of possible answers (2-4 options)
   - `media`: Optional media object displayed with the question:
     - `type`: `"image"`, `"video"`, or `"audio"`
-    - `url`: URL of the media
+    - `url`: URL of the media. Either a file uploaded through the editor (served under `/media/`) or an external URL. Images and audio can be uploaded; video is external-URL only.
   - `solutions`: Array of correct answer indices (0-based). Use multiple indices for multi-answer questions
   - `cooldown`: Time in seconds before answers are revealed (3-15)
   - `time`: Time in seconds allowed to answer (5-120)

--- a/docs/reverse-proxy.md
+++ b/docs/reverse-proxy.md
@@ -67,6 +67,6 @@ quiz.example.com {
 
 Any reverse proxy works as long as it:
 
-- Forwards all paths (`/`, `/branding/`, `/ws`) to the container's port `3000`
+- Forwards all paths (`/`, `/branding/`, `/ws`, `/api/`, `/media/`) to the container's port `3000` — the media API and uploaded images are served internally on `3000`, so there is no extra external requirement
 - Passes through `Upgrade` and `Connection` headers for WebSocket upgrades on `/ws`
 - Uses a generous read/idle timeout (players stay connected for the whole game, potentially longer than a default 60s timeout)

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev:web": "dotenv -e .env -- pnpm --filter web dev",
     "dev:socket": "dotenv -e .env -- pnpm --filter socket dev",
     "build": "pnpm -r run build",
+    "test": "pnpm -r run test",
     "start": "pnpm -r --parallel run start",
     "clean": "pnpm -r exec rm -rf dist node_modules",
     "lint": "oxlint",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,12 +1,17 @@
 {
   "name": "@razzia/common",
   "type": "module",
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
   "dependencies": {
     "socket.io": "^4.8.3",
     "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/node": "^26.0.1",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.11"
   }
 }

--- a/packages/common/src/constants.ts
+++ b/packages/common/src/constants.ts
@@ -82,6 +82,28 @@ export const MEDIA_TYPES = {
   AUDIO: "audio",
 } as const
 
+export type MediaType = (typeof MEDIA_TYPES)[keyof typeof MEDIA_TYPES]
+
+/**
+ * Media accepted for upload, keyed by the MIME the server detects from magic
+ * bytes, each mapping to the extension written to disk and the media type. The
+ * single source of truth for MIME → extension → type: the server derives the
+ * type at save time and the client consumes it rather than guessing from the
+ * URL. Video is not uploadable — it is attachable only by external URL.
+ */
+export const ACCEPTED_MEDIA_TYPES: Record<
+  string,
+  { ext: string; type: MediaType }
+> = {
+  "image/png": { ext: ".png", type: MEDIA_TYPES.IMAGE },
+  "image/jpeg": { ext: ".jpg", type: MEDIA_TYPES.IMAGE },
+  "image/webp": { ext: ".webp", type: MEDIA_TYPES.IMAGE },
+  "image/gif": { ext: ".gif", type: MEDIA_TYPES.IMAGE },
+  "audio/mpeg": { ext: ".mp3", type: MEDIA_TYPES.AUDIO },
+  "audio/ogg": { ext: ".ogg", type: MEDIA_TYPES.AUDIO },
+  "audio/wav": { ext: ".wav", type: MEDIA_TYPES.AUDIO },
+}
+
 export const EXAMPLE_QUIZZ = {
   subject: "Example Quizz",
   questions: [

--- a/packages/common/src/types/game/index.ts
+++ b/packages/common/src/types/game/index.ts
@@ -1,5 +1,5 @@
 import type {
-  MEDIA_TYPES,
+  MediaType,
   QUESTION_TYPES,
   SCORING_MODES,
 } from "@razzia/common/constants"
@@ -29,13 +29,22 @@ export interface Answer {
   points: number
 }
 
-export type QuestionMediaType =
-  | (typeof MEDIA_TYPES)[keyof typeof MEDIA_TYPES]
-  | undefined
+export type QuestionMediaType = MediaType | undefined
 
 export interface QuestionMedia {
   type?: QuestionMediaType
   url: string
+}
+
+/**
+ * A hosted media file returned by the media HTTP API (`/api/media`): its
+ * relative URL and the type the server derived from the file's magic bytes.
+ * Shared between Socket (produces it) and Web (consumes it). Only image and
+ * audio are uploadable — video is external-URL only.
+ */
+export interface StoredMedia {
+  url: string
+  type: MediaType
 }
 
 export interface Question {

--- a/packages/common/src/validators/quizz.test.ts
+++ b/packages/common/src/validators/quizz.test.ts
@@ -1,0 +1,30 @@
+import { MEDIA_TYPES } from "@razzia/common/constants"
+import { describe, expect, it } from "vitest"
+import { questionMediaValidator } from "./quizz"
+
+const parseUrl = (url: string) =>
+  questionMediaValidator.safeParse({ type: MEDIA_TYPES.IMAGE, url })
+
+describe("questionMediaValidator.url", () => {
+  it("accepts an absolute URL", () => {
+    expect(parseUrl("https://example.com/img.png").success).toBe(true)
+  })
+
+  it("accepts an in-platform /media/ path", () => {
+    expect(parseUrl("/media/V1StGXR8.png").success).toBe(true)
+  })
+
+  it("rejects an arbitrary absolute path", () => {
+    expect(parseUrl("/etc/passwd").success).toBe(false)
+    expect(parseUrl("/uploads/x.png").success).toBe(false)
+  })
+
+  it("rejects a relative or traversal path", () => {
+    expect(parseUrl("media/x.png").success).toBe(false)
+    expect(parseUrl("../media/x.png").success).toBe(false)
+  })
+
+  it("rejects a non-URL string", () => {
+    expect(parseUrl("not a url").success).toBe(false)
+  })
+})

--- a/packages/common/src/validators/quizz.ts
+++ b/packages/common/src/validators/quizz.ts
@@ -5,11 +5,19 @@ import {
 } from "@razzia/common/constants"
 import { z } from "zod"
 
+const MEDIA_PATH_PREFIX = "/media/"
+
 export const questionMediaValidator = z.object({
   type: z
     .enum([MEDIA_TYPES.IMAGE, MEDIA_TYPES.VIDEO, MEDIA_TYPES.AUDIO])
     .optional(),
-  url: z.url("errors:quizz.invalidMediaUrl"),
+  url: z
+    .string()
+    .refine(
+      (value) =>
+        value.startsWith(MEDIA_PATH_PREFIX) || z.url().safeParse(value).success,
+      "errors:quizz.invalidMediaUrl",
+    ),
 })
 
 const multiOptionsValidator = z.object({

--- a/packages/common/vitest.config.ts
+++ b/packages/common/vitest.config.ts
@@ -1,0 +1,13 @@
+import { fileURLToPath } from "url"
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@razzia/common": fileURLToPath(new URL("./src", import.meta.url)),
+    },
+  },
+  test: {
+    environment: "node",
+  },
+})

--- a/packages/socket/package.json
+++ b/packages/socket/package.json
@@ -4,12 +4,17 @@
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "build": "node esbuild.config.js",
-    "start": "node dist/index.cjs"
+    "start": "node dist/index.cjs",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "license": "ISC",
   "dependencies": {
     "@razzia/common": "workspace:*",
     "dayjs": "^1.11.21",
+    "express": "^5.2.1",
+    "file-type": "^22.0.2",
+    "multer": "^2.2.0",
     "nanoid": "^5.1.16",
     "socket.io": "^4.8.3",
     "typescript": "^6.0.3",
@@ -17,8 +22,13 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@types/express": "^5.0.6",
+    "@types/multer": "^2.2.0",
     "@types/node": "^26.0.1",
+    "@types/supertest": "^7.2.1",
     "esbuild": "^0.28.1",
-    "tsx": "^4.22.4"
+    "supertest": "^7.2.2",
+    "tsx": "^4.22.4",
+    "vitest": "^4.1.11"
   }
 }

--- a/packages/socket/src/http/auth.ts
+++ b/packages/socket/src/http/auth.ts
@@ -1,0 +1,19 @@
+import manager from "@razzia/socket/services/manager"
+import type { NextFunction, Request, Response } from "express"
+
+// `X-Client-Id` is the socket handshake's `clientId`; scheme: ADR-0001 amendment.
+export const requireManager = (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): void => {
+  const clientId = req.get("X-Client-Id")
+
+  if (!clientId || !manager.isClientLogged(clientId)) {
+    res.status(401).json({ error: "Unauthorized" })
+
+    return
+  }
+
+  next()
+}

--- a/packages/socket/src/http/media.test.ts
+++ b/packages/socket/src/http/media.test.ts
@@ -1,0 +1,407 @@
+import type { Socket } from "@razzia/common/types/game/socket"
+import { createApp } from "@razzia/socket/http/server"
+import manager from "@razzia/socket/services/manager"
+import fs from "fs"
+import os from "os"
+import { join, resolve } from "path"
+import request from "supertest"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+
+const CLIENT_ID = "manager-client-id"
+
+const managerSocket = {
+  handshake: { auth: { clientId: CLIENT_ID } },
+} as unknown as Socket
+
+// Minimal valid image buffers — enough magic bytes for file-type to detect.
+const pngBuffer = (): Buffer => {
+  const signature = Buffer.from([
+    0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+  ])
+  const ihdr = Buffer.from([
+    0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52, 0x00, 0x00, 0x00, 0x01,
+    0x00, 0x00, 0x00, 0x01, 0x08, 0x06, 0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4,
+    0x89,
+  ])
+
+  return Buffer.concat([signature, ihdr])
+}
+
+// Minimal audio buffers — enough magic bytes for file-type to detect the type.
+const mp3Buffer = (): Buffer =>
+  Buffer.concat([
+    Buffer.from([0x49, 0x44, 0x33, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]),
+    Buffer.from([0xff, 0xfb, 0x90, 0x00]),
+  ])
+
+const oggPage = (payload: Buffer): Buffer => {
+  const header = Buffer.alloc(28)
+  header.write("OggS", 0, "ascii")
+
+  return Buffer.concat([header, payload, Buffer.alloc(8)])
+}
+
+const oggBuffer = (): Buffer =>
+  oggPage(Buffer.concat([Buffer.from([0x01]), Buffer.from("vorbis")]))
+
+const opusBuffer = (): Buffer => oggPage(Buffer.from("OpusHead"))
+
+const wavBuffer = (): Buffer =>
+  Buffer.concat([
+    Buffer.from([
+      0x52, 0x49, 0x46, 0x46, 0x24, 0x00, 0x00, 0x00, 0x57, 0x41, 0x56, 0x45,
+      0x66, 0x6d, 0x74, 0x20,
+    ]),
+    Buffer.alloc(40),
+  ])
+
+const mp4Buffer = (): Buffer =>
+  Buffer.concat([
+    Buffer.from([0x00, 0x00, 0x00, 0x18]),
+    Buffer.from("ftypisom"),
+    Buffer.from([0x00, 0x00, 0x02, 0x00]),
+    Buffer.from("isommp41"),
+    Buffer.alloc(16),
+  ])
+
+const webmBuffer = (): Buffer =>
+  Buffer.concat([
+    Buffer.from([0x1a, 0x45, 0xdf, 0xa3, 0x9f, 0x42, 0x86, 0x81, 0x01]),
+    Buffer.from([0x42, 0x82, 0x84]),
+    Buffer.from("webm"),
+    Buffer.alloc(16),
+  ])
+
+let mediaDir = ""
+
+beforeEach(() => {
+  mediaDir = fs.mkdtempSync(join(os.tmpdir(), "razzia-media-"))
+  process.env.MEDIA_PATH = mediaDir
+  manager.login(managerSocket)
+})
+
+// Manager is a module-level singleton: log out so no test inherits a session.
+afterEach(() => {
+  manager.logout(managerSocket)
+  fs.rmSync(mediaDir, { recursive: true, force: true })
+  delete process.env.MEDIA_PATH
+})
+
+const filesInMediaDir = (): string[] =>
+  fs.existsSync(mediaDir) ? fs.readdirSync(mediaDir) : []
+
+describe("POST /api/media", () => {
+  it("rejects a request with no X-Client-Id header (401)", async () => {
+    const res = await request(createApp())
+      .post("/api/media")
+      .attach("file", pngBuffer(), {
+        filename: "x.png",
+        contentType: "image/png",
+      })
+
+    expect(res.status).toBe(401)
+    expect(filesInMediaDir()).toHaveLength(0)
+  })
+
+  it("rejects an unknown client id (401)", async () => {
+    const res = await request(createApp())
+      .post("/api/media")
+      .set("X-Client-Id", "unknown-client-id")
+      .attach("file", pngBuffer(), {
+        filename: "x.png",
+        contentType: "image/png",
+      })
+
+    expect(res.status).toBe(401)
+    expect(filesInMediaDir()).toHaveLength(0)
+  })
+
+  it("rejects a client id whose session has been logged out (401)", async () => {
+    manager.logout(managerSocket)
+
+    const res = await request(createApp())
+      .post("/api/media")
+      .set("X-Client-Id", CLIENT_ID)
+      .attach("file", pngBuffer(), {
+        filename: "x.png",
+        contentType: "image/png",
+      })
+
+    expect(res.status).toBe(401)
+    expect(filesInMediaDir()).toHaveLength(0)
+  })
+
+  it("accepts a valid image from a logged manager (201) and writes it to disk", async () => {
+    const res = await request(createApp())
+      .post("/api/media")
+      .set("X-Client-Id", CLIENT_ID)
+      .attach("file", pngBuffer(), {
+        filename: "x.png",
+        contentType: "image/png",
+      })
+
+    const body = res.body as { url: string; type: string }
+
+    expect(res.status).toBe(201)
+    expect(body.url).toMatch(/^\/media\/[\w-]+\.png$/u)
+    expect(body.type).toBe("image")
+
+    const name = body.url.replace("/media/", "")
+    expect(fs.existsSync(resolve(mediaDir, name))).toBe(true)
+  })
+
+  it.each([
+    { label: "mp3", buffer: mp3Buffer, mime: "audio/mpeg", ext: "mp3" },
+    { label: "ogg", buffer: oggBuffer, mime: "audio/ogg", ext: "ogg" },
+    { label: "wav", buffer: wavBuffer, mime: "audio/wav", ext: "wav" },
+  ])(
+    "accepts a valid $label upload (201), assigns .$ext and audio type",
+    async ({ buffer, mime, ext }) => {
+      const res = await request(createApp())
+        .post("/api/media")
+        .set("X-Client-Id", CLIENT_ID)
+        .attach("file", buffer(), { filename: `x.${ext}`, contentType: mime })
+
+      const body = res.body as { url: string; type: string }
+
+      expect(res.status).toBe(201)
+      expect(body.url).toMatch(new RegExp(`^/media/[\\w-]+\\.${ext}$`, "u"))
+      expect(body.type).toBe("audio")
+
+      const name = body.url.replace("/media/", "")
+      expect(fs.existsSync(resolve(mediaDir, name))).toBe(true)
+    },
+  )
+
+  it.each([
+    {
+      label: "Ogg audio declared as video/ogg (Firefox)",
+      buffer: oggBuffer,
+      mime: "video/ogg",
+      ext: "ogg",
+    },
+    { label: "Ogg Opus", buffer: opusBuffer, mime: "audio/ogg", ext: "ogg" },
+    {
+      label: "WAV declared as audio/x-wav",
+      buffer: wavBuffer,
+      mime: "audio/x-wav",
+      ext: "wav",
+    },
+  ])(
+    "accepts $label from its magic bytes regardless of the declared MIME (201)",
+    async ({ buffer, mime, ext }) => {
+      const res = await request(createApp())
+        .post("/api/media")
+        .set("X-Client-Id", CLIENT_ID)
+        .attach("file", buffer(), { filename: `x.${ext}`, contentType: mime })
+
+      const body = res.body as { url: string; type: string }
+
+      expect(res.status).toBe(201)
+      expect(body.url).toMatch(new RegExp(`^/media/[\\w-]+\\.${ext}$`, "u"))
+      expect(body.type).toBe("audio")
+    },
+  )
+
+  it.each([
+    { label: "mp4", buffer: mp4Buffer, mime: "video/mp4", ext: "mp4" },
+    { label: "webm", buffer: webmBuffer, mime: "video/webm", ext: "webm" },
+  ])(
+    "rejects a $label video with the video-not-hosted code (415)",
+    async ({ buffer, mime, ext }) => {
+      const res = await request(createApp())
+        .post("/api/media")
+        .set("X-Client-Id", CLIENT_ID)
+        .attach("file", buffer(), { filename: `x.${ext}`, contentType: mime })
+
+      expect(res.status).toBe(415)
+      expect((res.body as { code: string }).code).toBe("video-not-hosted")
+      expect(filesInMediaDir()).toHaveLength(0)
+    },
+  )
+
+  it("rejects a non-media file (415)", async () => {
+    const res = await request(createApp())
+      .post("/api/media")
+      .set("X-Client-Id", CLIENT_ID)
+      .attach("file", Buffer.from("hello world"), {
+        filename: "x.txt",
+        contentType: "text/plain",
+      })
+
+    expect(res.status).toBe(415)
+    expect((res.body as { code: string }).code).toBe("unsupported-type")
+    expect(filesInMediaDir()).toHaveLength(0)
+  })
+
+  it("rejects a spoofed MIME (non-image bytes sent as image/png) (415)", async () => {
+    const res = await request(createApp())
+      .post("/api/media")
+      .set("X-Client-Id", CLIENT_ID)
+      .attach("file", Buffer.from("<html>not an image</html>"), {
+        filename: "x.png",
+        contentType: "image/png",
+      })
+
+    expect(res.status).toBe(415)
+    expect(filesInMediaDir()).toHaveLength(0)
+  })
+
+  it("rejects an oversize file (413)", async () => {
+    const oversize = Buffer.concat([
+      pngBuffer(),
+      Buffer.alloc(20 * 1024 * 1024),
+    ])
+
+    const res = await request(createApp())
+      .post("/api/media")
+      .set("X-Client-Id", CLIENT_ID)
+      .attach("file", oversize, { filename: "x.png", contentType: "image/png" })
+
+    expect(res.status).toBe(413)
+    expect(filesInMediaDir()).toHaveLength(0)
+  })
+
+  it("returns 400 when no file part is present", async () => {
+    const res = await request(createApp())
+      .post("/api/media")
+      .set("X-Client-Id", CLIENT_ID)
+
+    expect(res.status).toBe(400)
+  })
+})
+
+describe("GET /api/media", () => {
+  it("rejects a request with no X-Client-Id header (401)", async () => {
+    const res = await request(createApp()).get("/api/media")
+
+    expect(res.status).toBe(401)
+  })
+
+  it("rejects an unknown client id (401)", async () => {
+    const res = await request(createApp())
+      .get("/api/media")
+      .set("X-Client-Id", "unknown-client-id")
+
+    expect(res.status).toBe(401)
+  })
+
+  it("rejects a client id whose session has been logged out (401)", async () => {
+    manager.logout(managerSocket)
+
+    const res = await request(createApp())
+      .get("/api/media")
+      .set("X-Client-Id", CLIENT_ID)
+
+    expect(res.status).toBe(401)
+  })
+
+  it("returns each accepted file as { url, type }, skipping unknown types (200)", async () => {
+    fs.writeFileSync(join(mediaDir, "a.png"), pngBuffer())
+    fs.writeFileSync(join(mediaDir, "b.mp3"), mp3Buffer())
+    fs.writeFileSync(join(mediaDir, "notes.txt"), "hello")
+
+    const res = await request(createApp())
+      .get("/api/media")
+      .set("X-Client-Id", CLIENT_ID)
+
+    const body = res.body as Array<{ url: string; type: string }>
+
+    expect(res.status).toBe(200)
+    expect(body).toHaveLength(2)
+    expect(body).toEqual(
+      expect.arrayContaining([
+        { url: "/media/a.png", type: "image" },
+        { url: "/media/b.mp3", type: "audio" },
+      ]),
+    )
+    expect(body.map((item) => item.url)).not.toContain("/media/notes.txt")
+  })
+
+  it("returns an empty array when the media directory has no media (200)", async () => {
+    const res = await request(createApp())
+      .get("/api/media")
+      .set("X-Client-Id", CLIENT_ID)
+
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual([])
+  })
+})
+
+describe("DELETE /api/media/:file", () => {
+  it("rejects a request with no X-Client-Id header (401)", async () => {
+    fs.writeFileSync(join(mediaDir, "a.png"), pngBuffer())
+
+    const res = await request(createApp()).delete("/api/media/a.png")
+
+    expect(res.status).toBe(401)
+    expect(filesInMediaDir()).toContain("a.png")
+  })
+
+  it("rejects an unknown client id (401)", async () => {
+    fs.writeFileSync(join(mediaDir, "a.png"), pngBuffer())
+
+    const res = await request(createApp())
+      .delete("/api/media/a.png")
+      .set("X-Client-Id", "unknown-client-id")
+
+    expect(res.status).toBe(401)
+    expect(filesInMediaDir()).toContain("a.png")
+  })
+
+  it("rejects a client id whose session has been logged out (401)", async () => {
+    fs.writeFileSync(join(mediaDir, "a.png"), pngBuffer())
+    manager.logout(managerSocket)
+
+    const res = await request(createApp())
+      .delete("/api/media/a.png")
+      .set("X-Client-Id", CLIENT_ID)
+
+    expect(res.status).toBe(401)
+    expect(filesInMediaDir()).toContain("a.png")
+  })
+
+  it("deletes the file for a logged manager (204) and removes it from disk", async () => {
+    fs.writeFileSync(join(mediaDir, "a.png"), pngBuffer())
+
+    const res = await request(createApp())
+      .delete("/api/media/a.png")
+      .set("X-Client-Id", CLIENT_ID)
+
+    expect(res.status).toBe(204)
+    expect(filesInMediaDir()).not.toContain("a.png")
+  })
+
+  it("rejects a malformed filename (400) without touching disk", async () => {
+    fs.writeFileSync(join(mediaDir, "a.png"), pngBuffer())
+
+    const res = await request(createApp())
+      .delete("/api/media/a.txt")
+      .set("X-Client-Id", CLIENT_ID)
+
+    expect(res.status).toBe(400)
+    expect(filesInMediaDir()).toContain("a.png")
+  })
+
+  it("rejects a traversal attempt without touching files outside the media dir", async () => {
+    const outside = join(mediaDir, "..", "secret.png")
+    fs.writeFileSync(outside, pngBuffer())
+
+    const res = await request(createApp())
+      .delete("/api/media/..%2Fsecret.png")
+      .set("X-Client-Id", CLIENT_ID)
+
+    expect([400, 404]).toContain(res.status)
+    expect(fs.existsSync(outside)).toBe(true)
+
+    fs.rmSync(outside, { force: true })
+  })
+
+  it("returns 404 for a well-formed name that does not exist", async () => {
+    const res = await request(createApp())
+      .delete("/api/media/V1StGXR8.png")
+      .set("X-Client-Id", CLIENT_ID)
+
+    expect(res.status).toBe(404)
+  })
+})

--- a/packages/socket/src/http/media.ts
+++ b/packages/socket/src/http/media.ts
@@ -1,0 +1,101 @@
+import { requireManager } from "@razzia/socket/http/auth"
+import { MediaError } from "@razzia/socket/services/media-errors"
+import {
+  deleteMedia,
+  listMedia,
+  MAX_MEDIA_BYTES,
+  saveMedia,
+} from "@razzia/socket/services/media"
+import { type NextFunction, type Request, type Response, Router } from "express"
+import multer, { MulterError } from "multer"
+
+const MEDIA_ERROR_STATUS: Record<MediaError["code"], number> = {
+  "unsupported-type": 415,
+  "video-not-hosted": 415,
+  "invalid-name": 400,
+  "not-found": 404,
+}
+
+// No fileFilter on the browser-declared MIME: browsers disagree on it (Firefox
+// sends video/ogg for Ogg audio), so saveMedia's magic-byte check is the only gate.
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: MAX_MEDIA_BYTES },
+})
+
+const handleUpload = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> => {
+  if (!req.file) {
+    res.status(400).json({ error: "No file provided" })
+
+    return
+  }
+
+  try {
+    const stored = await saveMedia(req.file.buffer)
+
+    res.status(201).json(stored)
+  } catch (error) {
+    next(error)
+  }
+}
+
+const handleList = (_req: Request, res: Response): void => {
+  res.status(200).json(listMedia())
+}
+
+const handleDelete = (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): void => {
+  try {
+    deleteMedia(req.params.file as string)
+
+    res.status(204).end()
+  } catch (error) {
+    next(error)
+  }
+}
+
+// Express recognises error-handling middleware by its four-arg signature.
+// eslint-disable-next-line max-params
+const handleError = (
+  error: unknown,
+  _req: Request,
+  res: Response,
+  next: NextFunction,
+): void => {
+  if (error instanceof MediaError) {
+    res
+      .status(MEDIA_ERROR_STATUS[error.code])
+      .json({ error: error.message, code: error.code })
+
+    return
+  }
+
+  if (error instanceof MulterError) {
+    if (error.code === "LIMIT_FILE_SIZE") {
+      res.status(413).json({ error: "File too large" })
+
+      return
+    }
+
+    res.status(400).json({ error: error.message })
+
+    return
+  }
+
+  next(error)
+}
+
+// eslint-disable-next-line new-cap
+export const mediaRouter = Router()
+
+mediaRouter.get("/media", requireManager, handleList)
+mediaRouter.post("/media", requireManager, upload.single("file"), handleUpload)
+mediaRouter.delete("/media/:file", requireManager, handleDelete)
+mediaRouter.use(handleError)

--- a/packages/socket/src/http/media.ts
+++ b/packages/socket/src/http/media.ts
@@ -35,7 +35,7 @@ const handleUpload = async (
   }
 
   try {
-    const stored = await saveMedia(req.file.buffer)
+    const stored = await saveMedia(req.file.buffer, req.file.originalname)
 
     res.status(201).json(stored)
   } catch (error) {

--- a/packages/socket/src/http/server.ts
+++ b/packages/socket/src/http/server.ts
@@ -1,0 +1,11 @@
+import { mediaRouter } from "@razzia/socket/http/media"
+import express, { type Express } from "express"
+
+export const createApp = (): Express => {
+  const app = express()
+
+  app.disable("x-powered-by")
+  app.use("/api", mediaRouter)
+
+  return app
+}

--- a/packages/socket/src/index.ts
+++ b/packages/socket/src/index.ts
@@ -4,19 +4,25 @@ import { managerSocketHandlers } from "@razzia/socket/handlers/manager"
 import { quizzSocketHandlers } from "@razzia/socket/handlers/quizz"
 import { resultsSocketHandlers } from "@razzia/socket/handlers/results"
 import type { SocketHandler } from "@razzia/socket/handlers/types"
+import { createApp } from "@razzia/socket/http/server"
 import { initConfig } from "@razzia/socket/services/config"
 import Registry from "@razzia/socket/services/registry"
+import http from "http"
 import { Server as ServerIO } from "socket.io"
 
 const WS_PORT = 3001
 
-const io: Server = new ServerIO({
+// Express and Socket.IO share one http.Server on port 3001 (ADR-0001): non-/ws
+// requests fall through to Express, WebSocket handlers are untouched.
+const app = createApp()
+const server = http.createServer(app)
+const io: Server = new ServerIO(server, {
   path: "/ws",
 })
 initConfig()
 
 console.log(`Socket server running on port ${WS_PORT}`)
-io.listen(WS_PORT)
+server.listen(WS_PORT)
 
 const socketHandlers: SocketHandler[] = [
   managerSocketHandlers,

--- a/packages/socket/src/services/manager.ts
+++ b/packages/socket/src/services/manager.ts
@@ -11,10 +11,14 @@ export const emitConfig = (socket: SocketContext["socket"]) =>
   })
 
 class Manager {
-  private loggedClients = new Set()
+  private loggedClients = new Set<string>()
+
+  isClientLogged(clientId: string): boolean {
+    return this.loggedClients.has(clientId)
+  }
 
   isLogged(socket: Socket) {
-    return this.loggedClients.has(getClientId(socket))
+    return this.isClientLogged(getClientId(socket))
   }
 
   login(socket: Socket) {

--- a/packages/socket/src/services/media-errors.ts
+++ b/packages/socket/src/services/media-errors.ts
@@ -1,0 +1,26 @@
+export type MediaErrorCode =
+  | "unsupported-type"
+  | "video-not-hosted"
+  | "invalid-name"
+  | "not-found"
+
+const MESSAGES: Record<MediaErrorCode, string> = {
+  "unsupported-type": "Unsupported media type",
+  "video-not-hosted": "Videos are not hosted; attach them by URL",
+  "invalid-name": "Invalid media filename",
+  "not-found": "Media not found",
+}
+
+/**
+ * A media operation failure. `code` lets the HTTP layer branch on the cause
+ * (bad upload type, malformed filename, missing file) without parsing messages.
+ */
+export class MediaError extends Error {
+  readonly code: MediaErrorCode
+
+  constructor(code: MediaErrorCode) {
+    super(MESSAGES[code])
+    this.name = "MediaError"
+    this.code = code
+  }
+}

--- a/packages/socket/src/services/media.ts
+++ b/packages/socket/src/services/media.ts
@@ -4,7 +4,7 @@ import { MediaError } from "@razzia/socket/services/media-errors"
 import { fileTypeFromBuffer } from "file-type"
 import fs from "fs"
 import { nanoid } from "nanoid"
-import { extname, resolve, sep } from "path"
+import { basename, extname, resolve, sep } from "path"
 
 /** Maximum accepted upload size, enforced by multer before the buffer completes. */
 export const MAX_MEDIA_BYTES = 20 * 1024 * 1024
@@ -32,12 +32,44 @@ export const ensureMediaDir = (): void => {
   }
 }
 
+/** Keeps the stored name readable while staying well under any path limit. */
+const MAX_BASE_LENGTH = 64
+
+/** Random part appended to the original name to keep stored names unique. */
+const SUFFIX_LENGTH = 6
+
+/**
+ * Reduces a browser-supplied name to the alphabet of MEDIA_NAME_PATTERN, so no
+ * path separator, dot segment or non-ASCII byte can survive into the filename.
+ * Multer decodes the name as latin1, hence the re-decode before folding accents.
+ */
+const sanitizeBaseName = (name: string): string => {
+  const decoded = Buffer.from(name, "latin1").toString("utf8")
+
+  return (
+    basename(decoded)
+      .replace(/\.[^.]*$/u, "")
+      .normalize("NFD")
+      .replace(/\p{Diacritic}/gu, "")
+      .replace(/[^A-Za-z0-9_-]+/gu, "-")
+      .replace(/-{2,}/gu, "-")
+      .replace(/^[-_]+|[-_]+$/gu, "")
+      .slice(0, MAX_BASE_LENGTH) || "media"
+  )
+}
+
 /**
  * Detects the real type from the buffer's magic bytes (never the client-declared
  * MIME), rejects anything not in the accepted-media allowlist, and writes
- * `${nanoid()}${ext}`. Returns the file's relative URL and its media type.
+ * `${sanitized original name}_${nanoid()}${ext}` — the original name is kept so
+ * the media library stays browsable, the random suffix avoids collisions. The
+ * extension always comes from the magic bytes, never from the uploaded name.
+ * Returns the file's relative URL and its media type.
  */
-export const saveMedia = async (buffer: Buffer): Promise<StoredMedia> => {
+export const saveMedia = async (
+  buffer: Buffer,
+  originalName = "",
+): Promise<StoredMedia> => {
   const detected = await fileTypeFromBuffer(buffer)
   // Some containers report a codec parameter (e.g. "audio/ogg; codecs=opus");
   // the allowlist is keyed by the bare MIME, so strip it before the lookup.
@@ -52,7 +84,13 @@ export const saveMedia = async (buffer: Buffer): Promise<StoredMedia> => {
 
   ensureMediaDir()
 
-  const name = `${nanoid()}${accepted.ext}`
+  const base = sanitizeBaseName(originalName)
+  let name = `${base}_${nanoid(SUFFIX_LENGTH)}${accepted.ext}`
+
+  while (fs.existsSync(getMediaPath(name))) {
+    name = `${base}_${nanoid(SUFFIX_LENGTH)}${accepted.ext}`
+  }
+
   fs.writeFileSync(getMediaPath(name), buffer)
 
   return { url: `/media/${name}`, type: accepted.type }
@@ -90,8 +128,10 @@ export const listMedia = (): StoredMedia[] => {
   })
 }
 
-// The nanoid + one of the actually-produced extensions. Any slash, backslash
-// or ".." fails to match, so a browser-supplied name can never escape the dir.
+// A stored name (sanitized base + nanoid suffix, or a bare nanoid for files
+// uploaded before names were kept) plus one of the actually-produced extensions.
+// Any slash, backslash or ".." fails to match, so a browser-supplied name can
+// never escape the dir.
 const NAME_EXTENSIONS = [...EXTENSION_TYPES.keys()]
   .map((ext) => ext.slice(1))
   .join("|")

--- a/packages/socket/src/services/media.ts
+++ b/packages/socket/src/services/media.ts
@@ -1,0 +1,127 @@
+import { ACCEPTED_MEDIA_TYPES } from "@razzia/common/constants"
+import type { StoredMedia } from "@razzia/common/types/game"
+import { MediaError } from "@razzia/socket/services/media-errors"
+import { fileTypeFromBuffer } from "file-type"
+import fs from "fs"
+import { nanoid } from "nanoid"
+import { extname, resolve, sep } from "path"
+
+/** Maximum accepted upload size, enforced by multer before the buffer completes. */
+export const MAX_MEDIA_BYTES = 20 * 1024 * 1024
+
+/** Extension (with dot) → media type, from the accepted-media allowlist. */
+const EXTENSION_TYPES = new Map(
+  Object.values(ACCEPTED_MEDIA_TYPES).map(({ ext, type }) => [ext, type]),
+)
+
+// `name` is either server-generated or already validated against
+// MEDIA_NAME_PATTERN; callers must never pass a raw browser-supplied name.
+export const getMediaPath = (name = ""): string => {
+  const mediaPathEnv = process.env.MEDIA_PATH
+
+  return mediaPathEnv
+    ? resolve(mediaPathEnv, name)
+    : resolve(process.cwd(), "../../media", name)
+}
+
+export const ensureMediaDir = (): void => {
+  const dir = getMediaPath()
+
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true })
+  }
+}
+
+/**
+ * Detects the real type from the buffer's magic bytes (never the client-declared
+ * MIME), rejects anything not in the accepted-media allowlist, and writes
+ * `${nanoid()}${ext}`. Returns the file's relative URL and its media type.
+ */
+export const saveMedia = async (buffer: Buffer): Promise<StoredMedia> => {
+  const detected = await fileTypeFromBuffer(buffer)
+  // Some containers report a codec parameter (e.g. "audio/ogg; codecs=opus");
+  // the allowlist is keyed by the bare MIME, so strip it before the lookup.
+  const mime = detected?.mime.split(";")[0].trim()
+  const accepted = mime ? ACCEPTED_MEDIA_TYPES[mime] : undefined
+
+  if (!accepted) {
+    throw new MediaError(
+      mime?.startsWith("video/") ? "video-not-hosted" : "unsupported-type",
+    )
+  }
+
+  ensureMediaDir()
+
+  const name = `${nanoid()}${accepted.ext}`
+  fs.writeFileSync(getMediaPath(name), buffer)
+
+  return { url: `/media/${name}`, type: accepted.type }
+}
+
+/**
+ * Lists the uploaded media as `{ url, type }`, the type derived from the file's
+ * extension via the accepted-media allowlist. Lstat (not stat) so a symlink
+ * planted in the dir is skipped instead of followed, mirroring listJsonFiles in
+ * services/config.ts.
+ */
+export const listMedia = (): StoredMedia[] => {
+  const dir = getMediaPath()
+
+  if (!fs.existsSync(dir)) {
+    return []
+  }
+
+  return fs.readdirSync(dir).flatMap((name) => {
+    const type = EXTENSION_TYPES.get(extname(name).toLowerCase())
+
+    if (!type) {
+      return []
+    }
+
+    try {
+      if (!fs.lstatSync(getMediaPath(name)).isFile()) {
+        return []
+      }
+    } catch {
+      return []
+    }
+
+    return [{ url: `/media/${name}`, type }]
+  })
+}
+
+// The nanoid + one of the actually-produced extensions. Any slash, backslash
+// or ".." fails to match, so a browser-supplied name can never escape the dir.
+const NAME_EXTENSIONS = [...EXTENSION_TYPES.keys()]
+  .map((ext) => ext.slice(1))
+  .join("|")
+const MEDIA_NAME_PATTERN = new RegExp(
+  `^[A-Za-z0-9_-]+\\.(${NAME_EXTENSIONS})$`,
+  "iu",
+)
+
+/**
+ * Deletes an uploaded image by its stored filename. Lstats (not stats) so a
+ * planted symlink is rejected rather than followed, as in listMedia.
+ */
+export const deleteMedia = (file: string): void => {
+  if (!MEDIA_NAME_PATTERN.test(file)) {
+    throw new MediaError("invalid-name")
+  }
+
+  const path = getMediaPath(file)
+
+  if (!path.startsWith(getMediaPath() + sep)) {
+    throw new MediaError("not-found")
+  }
+
+  try {
+    if (!fs.lstatSync(path).isFile()) {
+      throw new MediaError("not-found")
+    }
+  } catch {
+    throw new MediaError("not-found")
+  }
+
+  fs.unlinkSync(path)
+}

--- a/packages/socket/vitest.config.ts
+++ b/packages/socket/vitest.config.ts
@@ -1,0 +1,16 @@
+import { fileURLToPath } from "url"
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@razzia/socket": fileURLToPath(new URL("./src", import.meta.url)),
+      "@razzia/common": fileURLToPath(
+        new URL("../common/src", import.meta.url),
+      ),
+    },
+  },
+  test: {
+    environment: "node",
+  },
+})

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -5,7 +5,9 @@
     "dev": "vite",
     "build": "vite build",
     "start": "vite preview",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
@@ -41,11 +43,16 @@
   },
   "devDependencies": {
     "@tanstack/router-plugin": "^1.168.18",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.1.0",
+    "@testing-library/user-event": "^14.5.2",
     "@types/node": "^26.0.1",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.3",
+    "jsdom": "^25.0.1",
     "typescript": "~6.0.3",
-    "vite": "^8.1.0"
+    "vite": "^8.1.0",
+    "vitest": "^4.1.11"
   }
 }

--- a/packages/web/src/components/AlertDialog.tsx
+++ b/packages/web/src/components/AlertDialog.tsx
@@ -25,11 +25,11 @@ const AlertDialog = ({
       <RadixAlertDialog.Trigger asChild>{trigger}</RadixAlertDialog.Trigger>
 
       <RadixAlertDialog.Portal>
-        <RadixAlertDialog.Overlay className="data-[state=open]:animate-fade-in fixed inset-0 z-50 bg-black/40" />
+        <RadixAlertDialog.Overlay className="data-[state=open]:animate-fade-in fixed inset-0 z-[9999999999] bg-black/40" />
 
         <RadixAlertDialog.Content
           onClick={(e) => e.stopPropagation()}
-          className="bg-background fixed top-1/2 left-1/2 z-50 w-full max-w-lg -translate-x-1/2 -translate-y-1/2 rounded-xl p-6 shadow-xl"
+          className="bg-background fixed top-1/2 left-1/2 z-[9999999999] w-full max-w-lg -translate-x-1/2 -translate-y-1/2 rounded-xl p-6 shadow-xl"
         >
           <RadixAlertDialog.Title className="text-foreground text-lg font-semibold">
             {title}

--- a/packages/web/src/components/Modal.tsx
+++ b/packages/web/src/components/Modal.tsx
@@ -1,0 +1,41 @@
+import { X } from "lucide-react"
+import type { ReactNode } from "react"
+import { createPortal } from "react-dom"
+import { useTranslation } from "react-i18next"
+
+interface Props {
+  title: string
+  onClose: () => void
+  className?: string
+  children: ReactNode
+}
+
+const Modal = ({ title, onClose, className = "", children }: Props) => {
+  const { t } = useTranslation()
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-[9999999999] flex items-center justify-center bg-black/40 p-4"
+      onClick={onClose}
+    >
+      <div
+        role="dialog"
+        aria-label={title}
+        className={`bg-background flex flex-col gap-4 rounded-xl p-6 shadow-xl ${className}`}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between">
+          <h2 className="text-foreground text-lg font-semibold">{title}</h2>
+          <button onClick={onClose} aria-label={t("common:close")}>
+            <X className="text-foreground size-5" />
+          </button>
+        </div>
+
+        {children}
+      </div>
+    </div>,
+    document.body,
+  )
+}
+
+export default Modal

--- a/packages/web/src/features/quizz/api/media.ts
+++ b/packages/web/src/features/quizz/api/media.ts
@@ -1,0 +1,90 @@
+import { MEDIA_TYPES } from "@razzia/common/constants"
+import type { StoredMedia } from "@razzia/common/types/game"
+import { z } from "zod"
+
+// Media type vocabulary: see packages/common/CONTEXT.md.
+const storedMediaSchema = z.object({
+  url: z.string(),
+  type: z.enum([MEDIA_TYPES.IMAGE, MEDIA_TYPES.AUDIO]),
+})
+
+const listResponseSchema = z.array(storedMediaSchema)
+
+const errorResponseSchema = z.object({ code: z.string().optional() })
+
+export class MediaRequestError extends Error {
+  readonly status: number
+  readonly code?: string
+
+  constructor(status: number, code?: string) {
+    super(`Media request failed with status ${status}`)
+    this.name = "MediaRequestError"
+    this.status = status
+    this.code = code
+  }
+}
+
+export const isSessionExpired = (error: unknown): boolean =>
+  error instanceof MediaRequestError && error.status === 401
+
+const readErrorCode = async (
+  response: Response,
+): Promise<string | undefined> => {
+  const parsed = errorResponseSchema.safeParse(
+    await response.json().catch(() => undefined),
+  )
+
+  return parsed.success ? parsed.data.code : undefined
+}
+
+// Auth scheme: ADR-0001 amendment.
+const sessionHeaders = (clientId: string): HeadersInit => ({
+  "X-Client-Id": clientId,
+})
+
+export const uploadMedia = async (
+  file: File,
+  clientId: string,
+): Promise<StoredMedia> => {
+  const body = new FormData()
+  body.append("file", file)
+
+  const response = await fetch("/api/media", {
+    method: "POST",
+    headers: sessionHeaders(clientId),
+    body,
+  })
+
+  if (!response.ok) {
+    throw new MediaRequestError(response.status, await readErrorCode(response))
+  }
+
+  return storedMediaSchema.parse(await response.json())
+}
+
+export const listMedia = async (clientId: string): Promise<StoredMedia[]> => {
+  const response = await fetch("/api/media", {
+    headers: sessionHeaders(clientId),
+  })
+
+  if (!response.ok) {
+    throw new MediaRequestError(response.status)
+  }
+
+  return listResponseSchema.parse(await response.json())
+}
+
+export const deleteMedia = async (
+  file: string,
+  clientId: string,
+): Promise<void> => {
+  const response = await fetch(`/api/media/${encodeURIComponent(file)}`, {
+    method: "DELETE",
+    headers: sessionHeaders(clientId),
+  })
+
+  // 404 means the image is already gone — the desired end state, so idempotent.
+  if (!response.ok && response.status !== 404) {
+    throw new MediaRequestError(response.status)
+  }
+}

--- a/packages/web/src/features/quizz/components/QuestionEditor/MediaLibrary.test.tsx
+++ b/packages/web/src/features/quizz/components/QuestionEditor/MediaLibrary.test.tsx
@@ -1,0 +1,144 @@
+import type { QuizzWithId } from "@razzia/common/types/game"
+import { useSocket } from "@razzia/web/features/game/contexts/socket-context"
+import {
+  deleteMedia,
+  listMedia,
+  MediaRequestError,
+} from "@razzia/web/features/quizz/api/media"
+import MediaLibrary from "@razzia/web/features/quizz/components/QuestionEditor/MediaLibrary"
+import { QuizzEditorProvider } from "@razzia/web/features/quizz/contexts/quizz-editor-context"
+import "@razzia/web/i18n"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import toast from "react-hot-toast"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const navigate = vi.fn()
+
+vi.mock("@tanstack/react-router", () => ({
+  useNavigate: () => navigate,
+}))
+
+vi.mock("react-hot-toast", () => ({
+  default: { error: vi.fn() },
+}))
+
+vi.mock("@razzia/web/features/quizz/api/media", async (importOriginal) => ({
+  ...(await importOriginal<
+    typeof import("@razzia/web/features/quizz/api/media")
+  >()),
+  listMedia: vi.fn(),
+  deleteMedia: vi.fn(),
+}))
+
+const baseQuizz: QuizzWithId = {
+  id: "q1",
+  subject: "Test",
+  questions: [
+    {
+      type: "single",
+      question: "Q?",
+      answers: ["a", "b"],
+      solutions: [0],
+      cooldown: 5,
+      time: 20,
+    },
+  ],
+}
+
+// Exposes the id the socket handshake carries, so assertions compare against it.
+const ClientIdProbe = () => (
+  <span data-testid="client-id">{useSocket().clientId}</span>
+)
+
+const renderLibrary = (onClose = vi.fn()): { onClose: () => void } => {
+  render(
+    <QuizzEditorProvider initialData={baseQuizz}>
+      <ClientIdProbe />
+      <MediaLibrary onClose={onClose} />
+    </QuizzEditorProvider>,
+  )
+
+  return { onClose }
+}
+
+const socketClientId = (): string => screen.getByTestId("client-id").textContent
+
+describe("MediaLibrary", () => {
+  beforeEach(() => {
+    navigate.mockClear()
+    vi.mocked(toast.error).mockClear()
+    vi.mocked(listMedia).mockReset()
+    vi.mocked(deleteMedia).mockReset()
+  })
+
+  it("lists media using the socket client id, never a password", async () => {
+    vi.mocked(listMedia).mockResolvedValue([
+      { url: "/media/a.png", type: "image" },
+    ])
+
+    renderLibrary()
+
+    await screen.findByRole("button", { name: /delete media/i })
+
+    expect(listMedia).toHaveBeenCalledTimes(1)
+    const [[clientId]] = vi.mocked(listMedia).mock.calls
+    expect(clientId).toBe(socketClientId())
+    expect(clientId).not.toBe("")
+    expect(navigate).not.toHaveBeenCalled()
+  })
+
+  it("on 401 while deleting shows the session-expired toast, closes and redirects", async () => {
+    vi.mocked(listMedia).mockResolvedValue([
+      { url: "/media/a.png", type: "image" },
+    ])
+    vi.mocked(deleteMedia).mockRejectedValue(new MediaRequestError(401))
+
+    const { onClose } = renderLibrary()
+    const user = userEvent.setup()
+
+    await user.click(
+      await screen.findByRole("button", { name: /delete media/i }),
+    )
+    await user.click(screen.getByRole("button", { name: /^delete$/i }))
+
+    await waitFor(() =>
+      expect(navigate).toHaveBeenCalledWith({ to: "/manager" }),
+    )
+
+    expect(deleteMedia).toHaveBeenCalledWith("a.png", socketClientId())
+    expect(toast.error).toHaveBeenCalledWith(
+      "Your session has expired. Please sign in again.",
+    )
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it("on 401 shows the session-expired toast, closes and redirects to /manager", async () => {
+    vi.mocked(listMedia).mockRejectedValue(new MediaRequestError(401))
+
+    const { onClose } = renderLibrary()
+
+    await waitFor(() =>
+      expect(navigate).toHaveBeenCalledWith({ to: "/manager" }),
+    )
+
+    expect(toast.error).toHaveBeenCalledWith(
+      "Your session has expired. Please sign in again.",
+    )
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it("on another failure shows the list-failed toast without redirecting", async () => {
+    vi.mocked(listMedia).mockRejectedValue(new MediaRequestError(500))
+
+    const { onClose } = renderLibrary()
+
+    await waitFor(() => expect(onClose).toHaveBeenCalled())
+
+    expect(toast.error).toHaveBeenCalledTimes(1)
+    expect(toast.error).not.toHaveBeenCalledWith(
+      "Your session has expired. Please sign in again.",
+    )
+    expect(navigate).not.toHaveBeenCalled()
+  })
+})

--- a/packages/web/src/features/quizz/components/QuestionEditor/MediaLibrary.tsx
+++ b/packages/web/src/features/quizz/components/QuestionEditor/MediaLibrary.tsx
@@ -1,0 +1,138 @@
+import type { StoredMedia } from "@razzia/common/types/game"
+import { questionMediaValidator } from "@razzia/common/validators/quizz"
+import AlertDialog from "@razzia/web/components/AlertDialog"
+import Loader from "@razzia/web/components/Loader"
+import Modal from "@razzia/web/components/Modal"
+import { useSocket } from "@razzia/web/features/game/contexts/socket-context"
+import { deleteMedia, listMedia } from "@razzia/web/features/quizz/api/media"
+import { useQuizzEditor } from "@razzia/web/features/quizz/contexts/quizz-editor-context"
+import { useSessionExpiredRedirect } from "@razzia/web/features/quizz/hooks/useSessionExpiredRedirect"
+import { Music, Trash2 } from "lucide-react"
+import { useEffect, useState } from "react"
+import toast from "react-hot-toast"
+import { useTranslation } from "react-i18next"
+
+interface Props {
+  onClose: () => void
+}
+
+const fileNameFromUrl = (url: string): string => url.replace(/^\/media\//u, "")
+
+const MediaLibrary = ({ onClose }: Props) => {
+  const { updateQuestion, currentIndex } = useQuizzEditor()
+  const { clientId } = useSocket()
+  const redirectIfSessionExpired = useSessionExpiredRedirect()
+  const { t } = useTranslation()
+  const [items, setItems] = useState<StoredMedia[] | null>(null)
+
+  useEffect(() => {
+    listMedia(clientId)
+      .then(setItems)
+      .catch((error: unknown) => {
+        if (!redirectIfSessionExpired(error)) {
+          toast.error(t("errors:media.listFailed"))
+        }
+
+        onClose()
+      })
+    // oxlint-disable-next-line
+  }, [])
+
+  const handleSelect = (item: StoredMedia) => () => {
+    const result = questionMediaValidator.safeParse(item)
+
+    if (!result.success) {
+      toast.error(t(result.error.issues[0].message))
+
+      return
+    }
+
+    updateQuestion(currentIndex, { media: result.data })
+    onClose()
+  }
+
+  const handleDelete = (url: string) => async () => {
+    try {
+      await deleteMedia(fileNameFromUrl(url), clientId)
+      setItems((current) => (current ?? []).filter((item) => item.url !== url))
+    } catch (error) {
+      if (redirectIfSessionExpired(error)) {
+        onClose()
+
+        return
+      }
+
+      toast.error(t("errors:media.deleteFailed"))
+    }
+  }
+
+  return (
+    <Modal
+      title={t("quizz:question.mediaLibrary")}
+      onClose={onClose}
+      className="h-[90vh] w-[90vw] overflow-hidden"
+    >
+      {items === null && (
+        <div className="flex flex-1 items-center justify-center py-12">
+          <Loader className="text-foreground size-12" />
+        </div>
+      )}
+
+      {items?.length === 0 && (
+        <p className="text-muted-foreground py-12 text-center text-sm">
+          {t("quizz:question.mediaLibraryEmpty")}
+        </p>
+      )}
+
+      {items && items.length > 0 && (
+        <div className="grid min-h-0 flex-1 auto-rows-min grid-cols-[repeat(auto-fill,minmax(140px,1fr))] gap-3 overflow-y-auto">
+          {items.map((item) => (
+            <div
+              key={item.url}
+              className="hover:ring-primary group relative aspect-square overflow-hidden rounded-md ring-2 ring-transparent transition"
+            >
+              <button
+                onClick={handleSelect(item)}
+                aria-label={t("quizz:question.selectMedia")}
+                className="h-full w-full"
+              >
+                {item.type === "audio" ? (
+                  <span className="bg-accent text-accent-foreground flex h-full w-full flex-col items-center justify-center gap-1 p-2">
+                    <Music className="size-8" />
+                    <span className="w-full truncate text-center text-xs">
+                      {fileNameFromUrl(item.url)}
+                    </span>
+                  </span>
+                ) : (
+                  <img
+                    src={item.url}
+                    alt=""
+                    className="h-full w-full object-cover"
+                    loading="lazy"
+                  />
+                )}
+              </button>
+              <AlertDialog
+                trigger={
+                  <button
+                    onClick={(e) => e.stopPropagation()}
+                    aria-label={t("quizz:question.deleteMedia")}
+                    className="text-muted-foreground bg-background absolute top-1.5 right-1.5 hidden rounded-sm p-1 group-hover:block hover:bg-red-50 hover:text-red-500"
+                  >
+                    <Trash2 className="size-4" />
+                  </button>
+                }
+                title={t("quizz:question.deleteMedia")}
+                description={t("quizz:question.deleteMediaWarning")}
+                confirmLabel={t("common:delete")}
+                onConfirm={handleDelete(item.url)}
+              />
+            </div>
+          ))}
+        </div>
+      )}
+    </Modal>
+  )
+}
+
+export default MediaLibrary

--- a/packages/web/src/features/quizz/components/QuestionEditor/MediaLibrary.tsx
+++ b/packages/web/src/features/quizz/components/QuestionEditor/MediaLibrary.tsx
@@ -7,7 +7,7 @@ import { useSocket } from "@razzia/web/features/game/contexts/socket-context"
 import { deleteMedia, listMedia } from "@razzia/web/features/quizz/api/media"
 import { useQuizzEditor } from "@razzia/web/features/quizz/contexts/quizz-editor-context"
 import { useSessionExpiredRedirect } from "@razzia/web/features/quizz/hooks/useSessionExpiredRedirect"
-import { Music, Trash2 } from "lucide-react"
+import { LayoutGrid, List, Music, Trash2 } from "lucide-react"
 import { useEffect, useState } from "react"
 import toast from "react-hot-toast"
 import { useTranslation } from "react-i18next"
@@ -18,12 +18,45 @@ interface Props {
 
 const fileNameFromUrl = (url: string): string => url.replace(/^\/media\//u, "")
 
+type View = "grid" | "list"
+
+// The grid is best for images, the list for audio — where the file name is the
+// only thing to go by. The choice is remembered so it does not have to be made
+// again on every visit.
+const VIEW_STORAGE_KEY = "media-library-view"
+
+const readStoredView = (): View =>
+  localStorage.getItem(VIEW_STORAGE_KEY) === "list" ? "list" : "grid"
+
+interface ThumbnailProps {
+  item: StoredMedia
+  className: string
+  iconClassName: string
+}
+
+const Thumbnail = ({ item, className, iconClassName }: ThumbnailProps) =>
+  item.type === "audio" ? (
+    <span
+      className={`bg-accent text-accent-foreground flex items-center justify-center ${className}`}
+    >
+      <Music className={iconClassName} />
+    </span>
+  ) : (
+    <img
+      src={item.url}
+      alt=""
+      className={`object-cover ${className}`}
+      loading="lazy"
+    />
+  )
+
 const MediaLibrary = ({ onClose }: Props) => {
   const { updateQuestion, currentIndex } = useQuizzEditor()
   const { clientId } = useSocket()
   const redirectIfSessionExpired = useSessionExpiredRedirect()
   const { t } = useTranslation()
   const [items, setItems] = useState<StoredMedia[] | null>(null)
+  const [view, setView] = useState<View>(readStoredView)
 
   useEffect(() => {
     listMedia(clientId)
@@ -66,6 +99,29 @@ const MediaLibrary = ({ onClose }: Props) => {
     }
   }
 
+  const handleView = (next: View) => () => {
+    setView(next)
+    localStorage.setItem(VIEW_STORAGE_KEY, next)
+  }
+
+  const renderDelete = (url: string, className: string) => (
+    <AlertDialog
+      trigger={
+        <button
+          onClick={(e) => e.stopPropagation()}
+          aria-label={t("quizz:question.deleteMedia")}
+          className={`text-muted-foreground rounded-sm p-1 hover:bg-red-50 hover:text-red-500 ${className}`}
+        >
+          <Trash2 className="size-4" />
+        </button>
+      }
+      title={t("quizz:question.deleteMedia")}
+      description={t("quizz:question.deleteMediaWarning")}
+      confirmLabel={t("common:delete")}
+      onConfirm={handleDelete(url)}
+    />
+  )
+
   return (
     <Modal
       title={t("quizz:question.mediaLibrary")}
@@ -85,51 +141,84 @@ const MediaLibrary = ({ onClose }: Props) => {
       )}
 
       {items && items.length > 0 && (
-        <div className="grid min-h-0 flex-1 auto-rows-min grid-cols-[repeat(auto-fill,minmax(140px,1fr))] gap-3 overflow-y-auto">
-          {items.map((item) => (
-            <div
-              key={item.url}
-              className="hover:ring-primary group relative aspect-square overflow-hidden rounded-md ring-2 ring-transparent transition"
+        <>
+          <div className="flex justify-end gap-1">
+            <button
+              onClick={handleView("grid")}
+              aria-label={t("quizz:question.gridView")}
+              aria-pressed={view === "grid"}
+              className="text-muted-foreground aria-pressed:bg-accent aria-pressed:text-accent-foreground rounded-md p-1.5"
             >
-              <button
-                onClick={handleSelect(item)}
-                aria-label={t("quizz:question.selectMedia")}
-                className="h-full w-full"
-              >
-                {item.type === "audio" ? (
-                  <span className="bg-accent text-accent-foreground flex h-full w-full flex-col items-center justify-center gap-1 p-2">
-                    <Music className="size-8" />
-                    <span className="w-full truncate text-center text-xs">
+              <LayoutGrid className="size-4" />
+            </button>
+            <button
+              onClick={handleView("list")}
+              aria-label={t("quizz:question.listView")}
+              aria-pressed={view === "list"}
+              className="text-muted-foreground aria-pressed:bg-accent aria-pressed:text-accent-foreground rounded-md p-1.5"
+            >
+              <List className="size-4" />
+            </button>
+          </div>
+
+          {view === "grid" ? (
+            <div className="grid min-h-0 flex-1 auto-rows-min grid-cols-[repeat(auto-fill,minmax(140px,1fr))] gap-3 overflow-y-auto">
+              {items.map((item) => (
+                <div
+                  key={item.url}
+                  className="hover:ring-primary group bg-accent/40 relative flex flex-col overflow-hidden rounded-lg ring-2 ring-transparent transition"
+                >
+                  <button
+                    onClick={handleSelect(item)}
+                    aria-label={t("quizz:question.selectMedia")}
+                    className="aspect-square w-full"
+                  >
+                    <Thumbnail
+                      item={item}
+                      className="h-full w-full"
+                      iconClassName="size-8"
+                    />
+                  </button>
+                  <span
+                    className="text-muted-foreground truncate px-2 py-1.5 text-xs"
+                    title={fileNameFromUrl(item.url)}
+                  >
+                    {fileNameFromUrl(item.url)}
+                  </span>
+                  {renderDelete(
+                    item.url,
+                    "bg-background absolute top-1.5 right-1.5 hidden group-hover:block",
+                  )}
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div className="flex min-h-0 flex-1 flex-col gap-1 overflow-y-auto">
+              {items.map((item) => (
+                <div
+                  key={item.url}
+                  className="hover:bg-accent/40 flex items-center gap-3 rounded-lg pr-2 transition"
+                >
+                  <button
+                    onClick={handleSelect(item)}
+                    aria-label={t("quizz:question.selectMedia")}
+                    className="flex min-w-0 flex-1 items-center gap-3 py-1 text-left"
+                  >
+                    <Thumbnail
+                      item={item}
+                      className="size-12 shrink-0 rounded-md"
+                      iconClassName="size-5"
+                    />
+                    <span className="text-foreground min-w-0 flex-1 truncate text-sm">
                       {fileNameFromUrl(item.url)}
                     </span>
-                  </span>
-                ) : (
-                  <img
-                    src={item.url}
-                    alt=""
-                    className="h-full w-full object-cover"
-                    loading="lazy"
-                  />
-                )}
-              </button>
-              <AlertDialog
-                trigger={
-                  <button
-                    onClick={(e) => e.stopPropagation()}
-                    aria-label={t("quizz:question.deleteMedia")}
-                    className="text-muted-foreground bg-background absolute top-1.5 right-1.5 hidden rounded-sm p-1 group-hover:block hover:bg-red-50 hover:text-red-500"
-                  >
-                    <Trash2 className="size-4" />
                   </button>
-                }
-                title={t("quizz:question.deleteMedia")}
-                description={t("quizz:question.deleteMediaWarning")}
-                confirmLabel={t("common:delete")}
-                onConfirm={handleDelete(item.url)}
-              />
+                  {renderDelete(item.url, "shrink-0")}
+                </div>
+              ))}
             </div>
-          ))}
-        </div>
+          )}
+        </>
       )}
     </Modal>
   )

--- a/packages/web/src/features/quizz/components/QuestionEditor/MediaUrlDialog.test.tsx
+++ b/packages/web/src/features/quizz/components/QuestionEditor/MediaUrlDialog.test.tsx
@@ -1,0 +1,91 @@
+import type { QuizzWithId } from "@razzia/common/types/game"
+import MediaUrlDialog from "@razzia/web/features/quizz/components/QuestionEditor/MediaUrlDialog"
+import {
+  QuizzEditorProvider,
+  useQuizzEditor,
+} from "@razzia/web/features/quizz/contexts/quizz-editor-context"
+import "@razzia/web/i18n"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import type { ReactNode } from "react"
+import toast from "react-hot-toast"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("react-hot-toast", () => ({
+  default: { error: vi.fn() },
+}))
+
+const baseQuizz: QuizzWithId = {
+  id: "q1",
+  subject: "Test",
+  questions: [
+    {
+      type: "single",
+      question: "Q?",
+      answers: ["a", "b"],
+      solutions: [0],
+      cooldown: 5,
+      time: 20,
+    },
+  ],
+}
+
+// Surfaces the current question's media so assertions can read what attach wrote.
+const MediaProbe = () => {
+  const { currentQuestion } = useQuizzEditor()
+
+  return (
+    <span data-testid="media">{JSON.stringify(currentQuestion.media)}</span>
+  )
+}
+
+const renderDialog = (onClose = vi.fn()): { onClose: () => void } => {
+  const wrapper = (children: ReactNode) => (
+    <QuizzEditorProvider initialData={baseQuizz}>
+      <MediaProbe />
+      {children}
+    </QuizzEditorProvider>
+  )
+
+  render(wrapper(<MediaUrlDialog onClose={onClose} />))
+
+  return { onClose }
+}
+
+describe("MediaUrlDialog", () => {
+  beforeEach(() => {
+    vi.mocked(toast.error).mockClear()
+  })
+
+  it("attaches the URL with the clicked type and closes", async () => {
+    const user = userEvent.setup()
+    const { onClose } = renderDialog()
+
+    await user.type(
+      screen.getByPlaceholderText("Enter URL..."),
+      "https://example.com/clip.mp4",
+    )
+    await user.click(screen.getByRole("button", { name: /video/i }))
+
+    expect(
+      JSON.parse(screen.getByTestId("media").textContent || "null"),
+    ).toEqual({
+      type: "video",
+      url: "https://example.com/clip.mp4",
+    })
+    expect(onClose).toHaveBeenCalledOnce()
+    expect(toast.error).not.toHaveBeenCalled()
+  })
+
+  it("toasts and does not attach or close on an invalid URL", async () => {
+    const user = userEvent.setup()
+    const { onClose } = renderDialog()
+
+    await user.type(screen.getByPlaceholderText("Enter URL..."), "not a url")
+    await user.click(screen.getByRole("button", { name: /image/i }))
+
+    expect(screen.getByTestId("media").textContent).toBe("")
+    expect(onClose).not.toHaveBeenCalled()
+    expect(toast.error).toHaveBeenCalledOnce()
+  })
+})

--- a/packages/web/src/features/quizz/components/QuestionEditor/MediaUrlDialog.tsx
+++ b/packages/web/src/features/quizz/components/QuestionEditor/MediaUrlDialog.tsx
@@ -1,0 +1,74 @@
+import type { QuestionMediaType } from "@razzia/common/types/game"
+import { questionMediaValidator } from "@razzia/common/validators/quizz"
+import Button from "@razzia/web/components/Button"
+import Input from "@razzia/web/components/Input"
+import Modal from "@razzia/web/components/Modal"
+import { useQuizzEditor } from "@razzia/web/features/quizz/contexts/quizz-editor-context"
+import { Image, Link, type LucideIcon, Music, Video } from "lucide-react"
+import { useState } from "react"
+import toast from "react-hot-toast"
+import { useTranslation } from "react-i18next"
+
+interface Props {
+  onClose: () => void
+}
+
+const MEDIA_TYPE_OPTIONS: Array<{
+  type: QuestionMediaType
+  icon: LucideIcon
+  labelKey: string
+}> = [
+  { type: "image", icon: Image, labelKey: "quizz:question.media.image" },
+  { type: "audio", icon: Music, labelKey: "quizz:question.media.audio" },
+  { type: "video", icon: Video, labelKey: "quizz:question.media.video" },
+]
+
+const MediaUrlDialog = ({ onClose }: Props) => {
+  const { updateQuestion, currentIndex } = useQuizzEditor()
+  const { t } = useTranslation()
+  const [urlDraft, setUrlDraft] = useState("")
+
+  const attach = (type: QuestionMediaType) => () => {
+    const result = questionMediaValidator.safeParse({ type, url: urlDraft })
+
+    if (!result.success) {
+      toast.error(t(result.error.issues[0].message))
+
+      return
+    }
+
+    updateQuestion(currentIndex, { media: result.data })
+    onClose()
+  }
+
+  return (
+    <Modal
+      title={t("quizz:question.addFromUrlTitle")}
+      onClose={onClose}
+      className="w-full max-w-lg"
+    >
+      <Input
+        variant="sm"
+        placeholder={t("quizz:question.mediaUrlPlaceholder")}
+        value={urlDraft}
+        onChange={(e) => setUrlDraft(e.target.value)}
+      />
+
+      <div className="flex flex-wrap justify-center gap-1.5">
+        {MEDIA_TYPE_OPTIONS.map(({ type, icon: Icon, labelKey }) => (
+          <Button key={type} onClick={attach(type)} classNameContent="gap-1.5">
+            <Icon className="size-5" />
+            <p>{t(labelKey)}</p>
+          </Button>
+        ))}
+      </div>
+
+      <p className="text-muted-foreground flex items-center gap-1.5 text-xs">
+        <Link className="size-3.5 shrink-0" />
+        {t("quizz:question.externalLinkNotice")}
+      </p>
+    </Modal>
+  )
+}
+
+export default MediaUrlDialog

--- a/packages/web/src/features/quizz/components/QuestionEditor/QuestionEditorMedia.test.tsx
+++ b/packages/web/src/features/quizz/components/QuestionEditor/QuestionEditorMedia.test.tsx
@@ -1,0 +1,129 @@
+import type { QuizzWithId } from "@razzia/common/types/game"
+import { useSocket } from "@razzia/web/features/game/contexts/socket-context"
+import {
+  MediaRequestError,
+  uploadMedia,
+} from "@razzia/web/features/quizz/api/media"
+import QuestionEditorMedia from "@razzia/web/features/quizz/components/QuestionEditor/QuestionEditorMedia"
+import {
+  QuizzEditorProvider,
+  useQuizzEditor,
+} from "@razzia/web/features/quizz/contexts/quizz-editor-context"
+import "@razzia/web/i18n"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import toast from "react-hot-toast"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const navigate = vi.fn()
+
+vi.mock("@tanstack/react-router", () => ({
+  useNavigate: () => navigate,
+}))
+
+vi.mock("react-hot-toast", () => ({
+  default: { error: vi.fn() },
+}))
+
+vi.mock("@razzia/web/features/quizz/api/media", async (importOriginal) => ({
+  ...(await importOriginal<
+    typeof import("@razzia/web/features/quizz/api/media")
+  >()),
+  uploadMedia: vi.fn(),
+}))
+
+const baseQuizz: QuizzWithId = {
+  id: "q1",
+  subject: "Test",
+  questions: [
+    {
+      type: "single",
+      question: "Q?",
+      answers: ["a", "b"],
+      solutions: [0],
+      cooldown: 5,
+      time: 20,
+    },
+  ],
+}
+
+const MediaProbe = () => {
+  const { currentQuestion } = useQuizzEditor()
+
+  return (
+    <span data-testid="media">{JSON.stringify(currentQuestion.media)}</span>
+  )
+}
+
+// Exposes the id the socket handshake carries, so assertions compare against it.
+const ClientIdProbe = () => (
+  <span data-testid="client-id">{useSocket().clientId}</span>
+)
+
+const uploadPng = async (): Promise<void> => {
+  render(
+    <QuizzEditorProvider initialData={baseQuizz}>
+      <MediaProbe />
+      <ClientIdProbe />
+      <QuestionEditorMedia />
+    </QuizzEditorProvider>,
+  )
+
+  const input = screen.getByLabelText(/upload media/i)
+  const file = new File(["png"], "a.png", { type: "image/png" })
+
+  await userEvent.setup().upload(input, file)
+}
+
+describe("QuestionEditorMedia", () => {
+  beforeEach(() => {
+    navigate.mockClear()
+    vi.mocked(toast.error).mockClear()
+    vi.mocked(uploadMedia).mockReset()
+  })
+
+  it("uploads with the socket client id and attaches the stored media", async () => {
+    vi.mocked(uploadMedia).mockResolvedValue({
+      url: "/media/a.png",
+      type: "image",
+    })
+
+    await uploadPng()
+
+    await waitFor(() =>
+      expect(screen.getByTestId("media")).toHaveTextContent("/media/a.png"),
+    )
+
+    const [[, clientId]] = vi.mocked(uploadMedia).mock.calls
+    expect(clientId).toBe(screen.getByTestId("client-id").textContent)
+    expect(navigate).not.toHaveBeenCalled()
+  })
+
+  it("on 401 shows the session-expired toast and redirects to /manager", async () => {
+    vi.mocked(uploadMedia).mockRejectedValue(new MediaRequestError(401))
+
+    await uploadPng()
+
+    await waitFor(() =>
+      expect(navigate).toHaveBeenCalledWith({ to: "/manager" }),
+    )
+
+    expect(toast.error).toHaveBeenCalledTimes(1)
+    expect(toast.error).toHaveBeenCalledWith(
+      "Your session has expired. Please sign in again.",
+    )
+  })
+
+  it("on another failure shows the upload error without redirecting", async () => {
+    vi.mocked(uploadMedia).mockRejectedValue(new MediaRequestError(413))
+
+    await uploadPng()
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalledTimes(1))
+
+    expect(toast.error).not.toHaveBeenCalledWith(
+      "Your session has expired. Please sign in again.",
+    )
+    expect(navigate).not.toHaveBeenCalled()
+  })
+})

--- a/packages/web/src/features/quizz/components/QuestionEditor/QuestionEditorMedia.tsx
+++ b/packages/web/src/features/quizz/components/QuestionEditor/QuestionEditorMedia.tsx
@@ -1,34 +1,52 @@
-import type { QuestionMediaType } from "@razzia/common/types/game"
-import { questionMediaValidator } from "@razzia/common/validators/quizz"
+import { ACCEPTED_MEDIA_TYPES } from "@razzia/common/constants"
 import Button from "@razzia/web/components/Button"
 import Card from "@razzia/web/components/Card"
-import Input from "@razzia/web/components/Input"
 import QuestionMedia from "@razzia/web/components/QuestionMedia"
+import { useSocket } from "@razzia/web/features/game/contexts/socket-context"
+import {
+  MediaRequestError,
+  uploadMedia,
+} from "@razzia/web/features/quizz/api/media"
+import MediaLibrary from "@razzia/web/features/quizz/components/QuestionEditor/MediaLibrary"
+import MediaUrlDialog from "@razzia/web/features/quizz/components/QuestionEditor/MediaUrlDialog"
 import { useQuizzEditor } from "@razzia/web/features/quizz/contexts/quizz-editor-context"
-import { Image, ImageOff, Music, Video } from "lucide-react"
-import { type ChangeEvent } from "react"
+import { useSessionExpiredRedirect } from "@razzia/web/features/quizz/hooks/useSessionExpiredRedirect"
+import { isVideoFile } from "@razzia/web/features/quizz/utils/media"
+import { ImageOff, Library, Link, Upload } from "lucide-react"
+import { type ChangeEvent, useState } from "react"
 import toast from "react-hot-toast"
 import { useTranslation } from "react-i18next"
+
+const UPLOAD_ERROR_KEYS: Record<number, string> = {
+  413: "errors:media.tooLarge",
+  415: "errors:media.invalidType",
+}
+
+const uploadErrorKey = (error: unknown): string => {
+  if (!(error instanceof MediaRequestError)) {
+    return "errors:media.uploadFailed"
+  }
+
+  if (error.code === "video-not-hosted") {
+    return "errors:media.videoUpload"
+  }
+
+  return UPLOAD_ERROR_KEYS[error.status] ?? "errors:media.uploadFailed"
+}
+
+const UPLOAD_ACCEPT = Object.keys(ACCEPTED_MEDIA_TYPES).join(",")
+
+const MEDIA_BUTTON_CLASS =
+  "bg-accent text-accent-foreground hover:bg-accent transition-colors"
 
 const QuestionEditorMedia = () => {
   const { updateQuestion, currentIndex, currentQuestion } = useQuizzEditor()
   const questionMedia = currentQuestion.media
+  const { clientId } = useSocket()
+  const redirectIfSessionExpired = useSessionExpiredRedirect()
   const { t } = useTranslation()
-
-  const hadnleChangeMediaType = (type: QuestionMediaType) => () => {
-    const result = questionMediaValidator.safeParse({
-      type,
-      url: questionMedia?.url,
-    })
-
-    if (!result.success) {
-      toast.error(t(result.error.issues[0].message))
-
-      return
-    }
-
-    updateQuestion(currentIndex, { media: result.data })
-  }
+  const [isLibraryOpen, setIsLibraryOpen] = useState(false)
+  const [isUrlDialogOpen, setIsUrlDialogOpen] = useState(false)
 
   const handleRemoveMedia = () => {
     if (!questionMedia) {
@@ -38,10 +56,30 @@ const QuestionEditorMedia = () => {
     updateQuestion(currentIndex, { media: undefined })
   }
 
-  const handleChangeMedia = (e: ChangeEvent<HTMLInputElement>) => {
-    updateQuestion(currentIndex, {
-      media: { url: e.target.value },
-    })
+  const handleUploadMedia = async (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    e.target.value = ""
+
+    if (!file) {
+      return
+    }
+
+    if (isVideoFile(file)) {
+      toast.error(t("errors:media.videoUpload"))
+
+      return
+    }
+
+    try {
+      const { url, type } = await uploadMedia(file, clientId)
+      updateQuestion(currentIndex, { media: { type, url } })
+    } catch (error) {
+      if (redirectIfSessionExpired(error)) {
+        return
+      }
+
+      toast.error(t(uploadErrorKey(error)))
+    }
   }
 
   return (
@@ -54,42 +92,51 @@ const QuestionEditorMedia = () => {
           <p className="text-accent-foreground text-center text-sm">
             {t("quizz:question.addMediaHint")}
           </p>
-          <Input
-            variant="sm"
-            className="w-full max-w-md"
-            placeholder={t("quizz:question.mediaUrlPlaceholder")}
-            value={questionMedia?.url ?? ""}
-            onChange={handleChangeMedia}
-          />
+
+          <Button
+            onClick={() => setIsUrlDialogOpen(true)}
+            className={MEDIA_BUTTON_CLASS}
+            classNameContent="gap-1.5"
+          >
+            <Link className="size-5" />
+            <p>{t("quizz:question.addFromUrl")}</p>
+          </Button>
+
+          <div className="my-1 flex w-full max-w-md items-center gap-3">
+            <span className="bg-accent h-px flex-1" />
+            <span className="text-muted-foreground text-xs uppercase">
+              {t("common:or")}
+            </span>
+            <span className="bg-accent h-px flex-1" />
+          </div>
+
           <div className="flex flex-wrap justify-center gap-2">
+            <label
+              className={`${MEDIA_BUTTON_CLASS} flex cursor-pointer items-center gap-1.5 rounded-md px-4 py-2 font-semibold`}
+            >
+              <Upload className="size-6" />
+              <span>{t("quizz:question.uploadMedia")}</span>
+              <input
+                type="file"
+                accept={UPLOAD_ACCEPT}
+                className="hidden"
+                onChange={handleUploadMedia}
+              />
+            </label>
             <Button
-              onClick={hadnleChangeMediaType("image")}
-              className={`bg-accent text-accent-foreground hover:bg-accent transition-colors`}
+              onClick={() => setIsLibraryOpen(true)}
+              className={MEDIA_BUTTON_CLASS}
             >
               <div className="flex items-center gap-1.5">
-                <Image className="size-6" />
-                <p>{t("quizz:question.media.image")}</p>
-              </div>
-            </Button>
-            <Button
-              onClick={hadnleChangeMediaType("video")}
-              className={`bg-accent text-accent-foreground hover:bg-accent transition-colors`}
-            >
-              <div className="flex items-center gap-1.5">
-                <Video className="size-6" />
-                <p>{t("quizz:question.media.video")}</p>
-              </div>
-            </Button>
-            <Button
-              onClick={hadnleChangeMediaType("audio")}
-              className={`bg-accent text-accent-foreground hover:bg-accent transition-colors`}
-            >
-              <div className="flex items-center gap-1.5">
-                <Music className="size-6" />
-                <p>{t("quizz:question.media.audio")}</p>
+                <Library className="size-6" />
+                <p>{t("quizz:question.mediaLibrary")}</p>
               </div>
             </Button>
           </div>
+
+          <p className="text-muted-foreground text-xs">
+            {t("quizz:question.uploadNote")}
+          </p>
         </Card>
       )}
 
@@ -102,6 +149,14 @@ const QuestionEditorMedia = () => {
             {t("common:delete")}
           </Button>
         </div>
+      )}
+
+      {isLibraryOpen && (
+        <MediaLibrary onClose={() => setIsLibraryOpen(false)} />
+      )}
+
+      {isUrlDialogOpen && (
+        <MediaUrlDialog onClose={() => setIsUrlDialogOpen(false)} />
       )}
     </div>
   )

--- a/packages/web/src/features/quizz/hooks/useSessionExpiredRedirect.ts
+++ b/packages/web/src/features/quizz/hooks/useSessionExpiredRedirect.ts
@@ -1,0 +1,25 @@
+import { isSessionExpired } from "@razzia/web/features/quizz/api/media"
+import { useNavigate } from "@tanstack/react-router"
+import { useCallback } from "react"
+import toast from "react-hot-toast"
+import { useTranslation } from "react-i18next"
+
+// Mirrors the MANAGER.UNAUTHORIZED socket handler: back to the password screen.
+export const useSessionExpiredRedirect = () => {
+  const navigate = useNavigate()
+  const { t } = useTranslation()
+
+  return useCallback(
+    (error: unknown): boolean => {
+      if (!isSessionExpired(error)) {
+        return false
+      }
+
+      toast.error(t("errors:media.unauthorized"))
+      navigate({ to: "/manager" })
+
+      return true
+    },
+    [navigate, t],
+  )
+}

--- a/packages/web/src/features/quizz/utils/media.test.ts
+++ b/packages/web/src/features/quizz/utils/media.test.ts
@@ -1,0 +1,27 @@
+import { isVideoFile } from "@razzia/web/features/quizz/utils/media"
+import { describe, expect, it } from "vitest"
+
+const fileNamed = (name: string, type = ""): File =>
+  new File(["x"], name, { type })
+
+describe("isVideoFile", () => {
+  it("flags known video containers", () => {
+    for (const name of ["clip.mp4", "clip.webm", "clip.MOV", "clip.mkv"]) {
+      expect(isVideoFile(fileNamed(name))).toBe(true)
+    }
+  })
+
+  it("accepts images and audio in the allowlist", () => {
+    for (const name of ["pic.png", "pic.jpg", "sound.mp3", "sound.ogg"]) {
+      expect(isVideoFile(fileNamed(name))).toBe(false)
+    }
+  })
+
+  it("keeps Ogg audio uploadable even when the browser labels it video/ogg", () => {
+    expect(isVideoFile(fileNamed("sound.ogg", "video/ogg"))).toBe(false)
+  })
+
+  it("does not flag a file without an extension", () => {
+    expect(isVideoFile(fileNamed("noext"))).toBe(false)
+  })
+})

--- a/packages/web/src/features/quizz/utils/media.ts
+++ b/packages/web/src/features/quizz/utils/media.ts
@@ -1,0 +1,21 @@
+/**
+ * Extension-based rather than `file.type`, because Firefox reports Ogg audio as
+ * `video/ogg`. The server 415 stays as the safety net for anything not listed.
+ */
+const VIDEO_EXTENSIONS = new Set([
+  ".mp4",
+  ".webm",
+  ".mov",
+  ".mkv",
+  ".avi",
+  ".m4v",
+])
+
+const extensionOf = (name: string): string => {
+  const dot = name.lastIndexOf(".")
+
+  return dot === -1 ? "" : name.slice(dot).toLowerCase()
+}
+
+export const isVideoFile = (file: File): boolean =>
+  VIDEO_EXTENSIONS.has(extensionOf(file.name))

--- a/packages/web/src/locales/de/common.json
+++ b/packages/web/src/locales/de/common.json
@@ -1,5 +1,6 @@
 {
   "cancel": "Abbrechen",
+  "close": "Schließen",
   "confirm": "Bestätigen",
   "connecting": "Verbinden...",
   "delete": "Löschen",
@@ -17,5 +18,6 @@
   "save": "Speichern",
   "seconds": "Sek",
   "skip": "Überspringen",
-  "submit": "Absenden"
+  "submit": "Absenden",
+  "or": "oder"
 }

--- a/packages/web/src/locales/de/errors.json
+++ b/packages/web/src/locales/de/errors.json
@@ -19,6 +19,15 @@
     "invalidPassword": "Ungültiges Passwort",
     "passwordNotConfigured": "Manager-Passwort ist nicht konfiguriert"
   },
+  "media": {
+    "invalidType": "Nicht unterstützter Dateityp. Verwende ein Bild (PNG, JPEG, WebP, GIF) oder Audio (MP3, OGG, WAV).",
+    "listFailed": "Mediathek konnte nicht geladen werden. Bitte versuche es erneut.",
+    "tooLarge": "Datei ist zu groß (maximal 20 MB).",
+    "unauthorized": "Deine Sitzung ist abgelaufen. Bitte melde dich erneut an.",
+    "uploadFailed": "Upload fehlgeschlagen. Bitte versuche es erneut.",
+    "videoUpload": "Videos können nicht hochgeladen werden. Füge ein Video stattdessen per URL hinzu.",
+    "deleteFailed": "Die Datei konnte nicht gelöscht werden. Bitte versuche es erneut."
+  },
   "notFound": {
     "back": "Zurück zur Startseite",
     "description": "Die gesuchte Seite existiert nicht.",

--- a/packages/web/src/locales/de/quizz.json
+++ b/packages/web/src/locales/de/quizz.json
@@ -45,6 +45,8 @@
     "mediaLibraryEmpty": "Noch keine Medien hochgeladen",
     "placeholder": "Beginne deine Frage zu tippen...",
     "selectMedia": "Medium auswählen",
+    "gridView": "Rasteransicht",
+    "listView": "Listenansicht",
     "deleteMedia": "Medium löschen",
     "deleteMediaWarning": "Dieses Medium wird möglicherweise in anderen Quizzen verwendet — durch das Löschen könnten sie beschädigt werden."
   },

--- a/packages/web/src/locales/de/quizz.json
+++ b/packages/web/src/locales/de/quizz.json
@@ -36,7 +36,17 @@
       "video": "Video"
     },
     "mediaUrlPlaceholder": "URL eingeben...",
-    "placeholder": "Beginne deine Frage zu tippen..."
+    "addFromUrl": "Per URL hinzufügen",
+    "addFromUrlTitle": "Medium per URL hinzufügen",
+    "externalLinkNotice": "Dies fügt einen externen Link hinzu. Die Plattform hostet oder speichert dieses Medium nicht.",
+    "uploadNote": "* Nur Bilder oder Audio — Videos per URL hinzufügen",
+    "uploadMedia": "Medium hochladen",
+    "mediaLibrary": "Mediathek",
+    "mediaLibraryEmpty": "Noch keine Medien hochgeladen",
+    "placeholder": "Beginne deine Frage zu tippen...",
+    "selectMedia": "Medium auswählen",
+    "deleteMedia": "Medium löschen",
+    "deleteMediaWarning": "Dieses Medium wird möglicherweise in anderen Quizzen verwendet — durch das Löschen könnten sie beschädigt werden."
   },
   "quizzSaved": "Quiz erfolgreich gespeichert",
   "quizzUpdated": "Quiz erfolgreich aktualisiert",

--- a/packages/web/src/locales/en/common.json
+++ b/packages/web/src/locales/en/common.json
@@ -1,5 +1,6 @@
 {
   "cancel": "Cancel",
+  "close": "Close",
   "confirm": "Confirm",
   "connecting": "Connecting...",
   "delete": "Delete",
@@ -17,5 +18,6 @@
   "save": "Save",
   "seconds": "sec",
   "skip": "Skip",
-  "submit": "Submit"
+  "submit": "Submit",
+  "or": "or"
 }

--- a/packages/web/src/locales/en/errors.json
+++ b/packages/web/src/locales/en/errors.json
@@ -19,6 +19,15 @@
     "invalidPassword": "Invalid password",
     "passwordNotConfigured": "Manager password is not configured"
   },
+  "media": {
+    "invalidType": "Unsupported file type. Use an image (PNG, JPEG, WebP, GIF) or audio (MP3, OGG, WAV).",
+    "listFailed": "Failed to load the media library. Please try again.",
+    "tooLarge": "File is too large (maximum 20 MB).",
+    "unauthorized": "Your session has expired. Please sign in again.",
+    "uploadFailed": "Upload failed. Please try again.",
+    "videoUpload": "Videos can't be uploaded. Add a video by URL instead.",
+    "deleteFailed": "Failed to delete the file. Please try again."
+  },
   "notFound": {
     "back": "Go back home",
     "description": "The page you are looking for does not exist.",

--- a/packages/web/src/locales/en/quizz.json
+++ b/packages/web/src/locales/en/quizz.json
@@ -45,6 +45,8 @@
     "mediaLibraryEmpty": "No media uploaded yet",
     "placeholder": "Start typing your question...",
     "selectMedia": "Select media",
+    "gridView": "Grid view",
+    "listView": "List view",
     "deleteMedia": "Delete media",
     "deleteMediaWarning": "This media may be used in other quizzes — deleting it could break them."
   },

--- a/packages/web/src/locales/en/quizz.json
+++ b/packages/web/src/locales/en/quizz.json
@@ -36,7 +36,17 @@
       "video": "Video"
     },
     "mediaUrlPlaceholder": "Enter URL...",
-    "placeholder": "Start typing your question..."
+    "addFromUrl": "Add from URL",
+    "addFromUrlTitle": "Add media from a URL",
+    "externalLinkNotice": "This attaches an external link. The platform does not host or store this media.",
+    "uploadNote": "* Images or audio only — add videos by URL",
+    "uploadMedia": "Upload media",
+    "mediaLibrary": "Media library",
+    "mediaLibraryEmpty": "No media uploaded yet",
+    "placeholder": "Start typing your question...",
+    "selectMedia": "Select media",
+    "deleteMedia": "Delete media",
+    "deleteMediaWarning": "This media may be used in other quizzes — deleting it could break them."
   },
   "quizzSaved": "Quizz saved successfully",
   "quizzUpdated": "Quizz updated successfully",

--- a/packages/web/src/locales/es/common.json
+++ b/packages/web/src/locales/es/common.json
@@ -1,5 +1,6 @@
 {
   "cancel": "Cancelar",
+  "close": "Cerrar",
   "confirm": "Confirmar",
   "connecting": "Conectando...",
   "delete": "Eliminar",
@@ -17,5 +18,6 @@
   "save": "Guardar",
   "seconds": "seg",
   "skip": "Omitir",
-  "submit": "Enviar"
+  "submit": "Enviar",
+  "or": "o"
 }

--- a/packages/web/src/locales/es/errors.json
+++ b/packages/web/src/locales/es/errors.json
@@ -19,6 +19,15 @@
     "invalidPassword": "Contraseña incorrecta",
     "passwordNotConfigured": "La contraseña del administrador no está configurada"
   },
+  "media": {
+    "invalidType": "Tipo de archivo no admitido. Usa una imagen (PNG, JPEG, WebP, GIF) o audio (MP3, OGG, WAV).",
+    "listFailed": "No se pudo cargar la biblioteca multimedia. Inténtalo de nuevo.",
+    "tooLarge": "El archivo es demasiado grande (máximo 20 MB).",
+    "unauthorized": "Tu sesión ha caducado. Inicia sesión de nuevo.",
+    "uploadFailed": "Error al subir el archivo. Inténtalo de nuevo.",
+    "videoUpload": "Los videos no se pueden subir. Añade el video por URL en su lugar.",
+    "deleteFailed": "No se pudo eliminar el archivo. Inténtalo de nuevo."
+  },
   "notFound": {
     "back": "Volver al inicio",
     "description": "La página que buscas no existe.",

--- a/packages/web/src/locales/es/quizz.json
+++ b/packages/web/src/locales/es/quizz.json
@@ -36,7 +36,17 @@
       "video": "Video"
     },
     "mediaUrlPlaceholder": "Introduce la URL...",
-    "placeholder": "Empieza a escribir tu pregunta..."
+    "addFromUrl": "Añadir desde URL",
+    "addFromUrlTitle": "Añadir archivo desde una URL",
+    "externalLinkNotice": "Esto adjunta un enlace externo. La plataforma no aloja ni almacena este archivo.",
+    "uploadNote": "* Solo imágenes o audio — añade videos por URL",
+    "uploadMedia": "Subir un archivo multimedia",
+    "mediaLibrary": "Biblioteca multimedia",
+    "mediaLibraryEmpty": "Aún no hay archivos multimedia subidos",
+    "placeholder": "Empieza a escribir tu pregunta...",
+    "selectMedia": "Seleccionar archivo",
+    "deleteMedia": "Eliminar archivo",
+    "deleteMediaWarning": "Este archivo puede estar en uso en otros cuestionarios; eliminarlo podría romperlos."
   },
   "quizzSaved": "Cuestionario guardado con éxito",
   "quizzUpdated": "Cuestionario actualizado con éxito",

--- a/packages/web/src/locales/es/quizz.json
+++ b/packages/web/src/locales/es/quizz.json
@@ -45,6 +45,8 @@
     "mediaLibraryEmpty": "Aún no hay archivos multimedia subidos",
     "placeholder": "Empieza a escribir tu pregunta...",
     "selectMedia": "Seleccionar archivo",
+    "gridView": "Vista de cuadrícula",
+    "listView": "Vista de lista",
     "deleteMedia": "Eliminar archivo",
     "deleteMediaWarning": "Este archivo puede estar en uso en otros cuestionarios; eliminarlo podría romperlos."
   },

--- a/packages/web/src/locales/fr/common.json
+++ b/packages/web/src/locales/fr/common.json
@@ -1,5 +1,6 @@
 {
   "cancel": "Annuler",
+  "close": "Fermer",
   "confirm": "Confirmer",
   "connecting": "Connexion...",
   "delete": "Supprimer",
@@ -17,5 +18,6 @@
   "save": "Enregistrer",
   "seconds": "sec",
   "skip": "Passer",
-  "submit": "Valider"
+  "submit": "Valider",
+  "or": "ou"
 }

--- a/packages/web/src/locales/fr/errors.json
+++ b/packages/web/src/locales/fr/errors.json
@@ -19,6 +19,15 @@
     "invalidPassword": "Mot de passe invalide",
     "passwordNotConfigured": "Mot de passe manager non configuré"
   },
+  "media": {
+    "invalidType": "Type de fichier non pris en charge. Utilisez une image (PNG, JPEG, WebP, GIF) ou un audio (MP3, OGG, WAV).",
+    "listFailed": "Échec du chargement de la médiathèque. Veuillez réessayer.",
+    "tooLarge": "Le fichier est trop volumineux (20 Mo maximum).",
+    "unauthorized": "Votre session a expiré. Veuillez vous reconnecter.",
+    "uploadFailed": "Échec du téléversement. Veuillez réessayer.",
+    "videoUpload": "Les vidéos ne peuvent pas être téléversées. Ajoutez plutôt la vidéo par URL.",
+    "deleteFailed": "Échec de la suppression du fichier. Veuillez réessayer."
+  },
   "notFound": {
     "back": "Retour à l'accueil",
     "description": "La page que vous recherchez n'existe pas.",

--- a/packages/web/src/locales/fr/quizz.json
+++ b/packages/web/src/locales/fr/quizz.json
@@ -36,7 +36,17 @@
       "video": "Vidéo"
     },
     "mediaUrlPlaceholder": "Entrez l'URL...",
-    "placeholder": "Commencez à écrire votre question..."
+    "addFromUrl": "Ajouter depuis une URL",
+    "addFromUrlTitle": "Ajouter un média depuis une URL",
+    "externalLinkNotice": "Ceci ajoute un lien externe. La plateforme n'héberge ni ne stocke ce média.",
+    "uploadNote": "* Images ou audio uniquement — ajoutez les vidéos par URL",
+    "uploadMedia": "Téléverser un média",
+    "mediaLibrary": "Médiathèque",
+    "mediaLibraryEmpty": "Aucun média téléversé pour le moment",
+    "placeholder": "Commencez à écrire votre question...",
+    "selectMedia": "Sélectionner le média",
+    "deleteMedia": "Supprimer le média",
+    "deleteMediaWarning": "Ce média est peut-être utilisé dans d’autres quizz — le supprimer pourrait les casser."
   },
   "quizzSaved": "Quizz enregistré avec succès",
   "quizzUpdated": "Quizz mis à jour avec succès",

--- a/packages/web/src/locales/fr/quizz.json
+++ b/packages/web/src/locales/fr/quizz.json
@@ -45,6 +45,8 @@
     "mediaLibraryEmpty": "Aucun média téléversé pour le moment",
     "placeholder": "Commencez à écrire votre question...",
     "selectMedia": "Sélectionner le média",
+    "gridView": "Vue grille",
+    "listView": "Vue liste",
     "deleteMedia": "Supprimer le média",
     "deleteMediaWarning": "Ce média est peut-être utilisé dans d’autres quizz — le supprimer pourrait les casser."
   },

--- a/packages/web/src/locales/it/common.json
+++ b/packages/web/src/locales/it/common.json
@@ -1,5 +1,6 @@
 {
   "cancel": "Annulla",
+  "close": "Chiudi",
   "confirm": "Conferma",
   "connecting": "Connessione...",
   "delete": "Elimina",
@@ -17,5 +18,6 @@
   "save": "Salva",
   "seconds": "sec",
   "skip": "Salta",
-  "submit": "Invia"
+  "submit": "Invia",
+  "or": "o"
 }

--- a/packages/web/src/locales/it/errors.json
+++ b/packages/web/src/locales/it/errors.json
@@ -19,6 +19,15 @@
     "invalidPassword": "Password non valida",
     "passwordNotConfigured": "La password del gestore non è configurata"
   },
+  "media": {
+    "invalidType": "Tipo di file non supportato. Usa un'immagine (PNG, JPEG, WebP, GIF) o un audio (MP3, OGG, WAV).",
+    "listFailed": "Impossibile caricare la libreria multimediale. Riprova.",
+    "tooLarge": "Il file è troppo grande (massimo 20 MB).",
+    "unauthorized": "La tua sessione è scaduta. Effettua di nuovo l'accesso.",
+    "uploadFailed": "Caricamento non riuscito. Riprova.",
+    "videoUpload": "I video non possono essere caricati. Aggiungi il video tramite URL.",
+    "deleteFailed": "Impossibile eliminare il file. Riprova."
+  },
   "notFound": {
     "back": "Torna alla home",
     "description": "La pagina che cerchi non esiste.",

--- a/packages/web/src/locales/it/quizz.json
+++ b/packages/web/src/locales/it/quizz.json
@@ -45,6 +45,8 @@
     "mediaLibraryEmpty": "Nessun media caricato",
     "placeholder": "Inizia a scrivere la tua domanda...",
     "selectMedia": "Seleziona media",
+    "gridView": "Vista griglia",
+    "listView": "Vista elenco",
     "deleteMedia": "Elimina media",
     "deleteMediaWarning": "Questo media potrebbe essere usato in altri quiz — eliminarlo potrebbe comprometterli."
   },

--- a/packages/web/src/locales/it/quizz.json
+++ b/packages/web/src/locales/it/quizz.json
@@ -36,7 +36,17 @@
       "video": "Video"
     },
     "mediaUrlPlaceholder": "Inserisci URL...",
-    "placeholder": "Inizia a scrivere la tua domanda..."
+    "addFromUrl": "Aggiungi da URL",
+    "addFromUrlTitle": "Aggiungi media da un URL",
+    "externalLinkNotice": "Questo allega un link esterno. La piattaforma non ospita né archivia questo media.",
+    "uploadNote": "* Solo immagini o audio — aggiungi i video tramite URL",
+    "uploadMedia": "Carica un media",
+    "mediaLibrary": "Libreria multimediale",
+    "mediaLibraryEmpty": "Nessun media caricato",
+    "placeholder": "Inizia a scrivere la tua domanda...",
+    "selectMedia": "Seleziona media",
+    "deleteMedia": "Elimina media",
+    "deleteMediaWarning": "Questo media potrebbe essere usato in altri quiz — eliminarlo potrebbe comprometterli."
   },
   "quizzSaved": "Quiz salvato con successo",
   "quizzUpdated": "Quiz aggiornato con successo",

--- a/packages/web/src/locales/ja/common.json
+++ b/packages/web/src/locales/ja/common.json
@@ -1,5 +1,6 @@
 {
   "cancel": "キャンセル",
+  "close": "閉じる",
   "confirm": "確認",
   "connecting": "接続中...",
   "delete": "削除",
@@ -17,5 +18,6 @@
   "save": "保存",
   "seconds": "秒",
   "skip": "スキップ",
-  "submit": "送信"
+  "submit": "送信",
+  "or": "または"
 }

--- a/packages/web/src/locales/ja/errors.json
+++ b/packages/web/src/locales/ja/errors.json
@@ -19,6 +19,15 @@
     "invalidPassword": "パスワードが無効です",
     "passwordNotConfigured": "管理者パスワードが設定されていません"
   },
+  "media": {
+    "invalidType": "サポートされていないファイル形式です。画像（PNG、JPEG、WebP、GIF）または音声（MP3、OGG、WAV）を使用してください。",
+    "listFailed": "メディアライブラリの読み込みに失敗しました。もう一度お試しください。",
+    "tooLarge": "ファイルが大きすぎます（最大 20 MB）。",
+    "unauthorized": "セッションの有効期限が切れました。もう一度ログインしてください。",
+    "uploadFailed": "アップロードに失敗しました。もう一度お試しください。",
+    "videoUpload": "動画はアップロードできません。代わりにURLで追加してください。",
+    "deleteFailed": "ファイルの削除に失敗しました。もう一度お試しください。"
+  },
   "notFound": {
     "back": "ホームに戻る",
     "description": "お探しのページは存在しません。",

--- a/packages/web/src/locales/ja/quizz.json
+++ b/packages/web/src/locales/ja/quizz.json
@@ -45,6 +45,8 @@
     "mediaLibraryEmpty": "アップロードされたメディアはまだありません",
     "placeholder": "質問を入力してください...",
     "selectMedia": "メディアを選択",
+    "gridView": "グリッド表示",
+    "listView": "リスト表示",
     "deleteMedia": "メディアを削除",
     "deleteMediaWarning": "このメディアは他のクイズで使われている可能性があります。削除すると壊れることがあります。"
   },

--- a/packages/web/src/locales/ja/quizz.json
+++ b/packages/web/src/locales/ja/quizz.json
@@ -36,7 +36,17 @@
       "video": "動画"
     },
     "mediaUrlPlaceholder": "URLを入力...",
-    "placeholder": "質問を入力してください..."
+    "addFromUrl": "URLから追加",
+    "addFromUrlTitle": "URLからメディアを追加",
+    "externalLinkNotice": "これは外部リンクを添付します。このメディアはプラットフォームでホストまたは保存されません。",
+    "uploadNote": "※ 画像または音声のみ — 動画はURLで追加してください",
+    "uploadMedia": "メディアをアップロード",
+    "mediaLibrary": "メディアライブラリ",
+    "mediaLibraryEmpty": "アップロードされたメディアはまだありません",
+    "placeholder": "質問を入力してください...",
+    "selectMedia": "メディアを選択",
+    "deleteMedia": "メディアを削除",
+    "deleteMediaWarning": "このメディアは他のクイズで使われている可能性があります。削除すると壊れることがあります。"
   },
   "quizzSaved": "クイズを保存しました",
   "quizzUpdated": "クイズを更新しました",

--- a/packages/web/src/test/setup.ts
+++ b/packages/web/src/test/setup.ts
@@ -1,0 +1,8 @@
+import "@testing-library/jest-dom/vitest"
+
+import { cleanup } from "@testing-library/react"
+import { afterEach } from "vitest"
+
+afterEach(() => {
+  cleanup()
+})

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -7,10 +7,90 @@ import path from "node:path"
 import { fileURLToPath } from "url"
 import { defineConfig, type Plugin } from "vite"
 import { version } from "../../package.json"
+import { ACCEPTED_MEDIA_TYPES } from "../common/src/constants"
 
 const brandingDir = fileURLToPath(
   new URL("../../config/branding", import.meta.url),
 )
+
+// Same physical dir as the socket's dev default (<repo-root>/media), so a file
+// uploaded through the dev backend is immediately servable here.
+const mediaDir = fileURLToPath(new URL("../../media", import.meta.url))
+
+const mediaMimeTypes: Record<string, string> = Object.fromEntries(
+  Object.entries(ACCEPTED_MEDIA_TYPES).map(([mime, { ext }]) => [ext, mime]),
+)
+
+const serveMedia = (
+  req: IncomingMessage,
+  res: ServerResponse,
+  next: () => void,
+): void => {
+  if (!req.url?.startsWith("/media/")) {
+    next()
+
+    return
+  }
+
+  const [relative] = req.url.replace(/^\/media\//, "").split("?")
+  const filePath = path.join(mediaDir, relative)
+
+  if (!filePath.startsWith(mediaDir + path.sep) || !fs.existsSync(filePath)) {
+    res.statusCode = 404
+    res.end()
+
+    return
+  }
+
+  // Mirror the production nginx headers so dev and prod behave the same:
+  // <audio>/<video> need Content-Length and Range (206) to seek and know the duration.
+  const { size } = fs.statSync(filePath)
+  res.setHeader("X-Content-Type-Options", "nosniff")
+  res.setHeader("Accept-Ranges", "bytes")
+  res.setHeader(
+    "Content-Type",
+    mediaMimeTypes[path.extname(filePath)] ?? "application/octet-stream",
+  )
+
+  const range = /^bytes=(\d*)-(\d*)$/u.exec(req.headers.range ?? "")
+
+  if (!range) {
+    res.setHeader("Content-Length", size)
+    fs.createReadStream(filePath).pipe(res)
+
+    return
+  }
+
+  const start = range[1]
+    ? Number(range[1])
+    : Math.max(0, size - Number(range[2]))
+  const end =
+    range[1] && range[2] ? Math.min(Number(range[2]), size - 1) : size - 1
+
+  if (start >= size || start > end) {
+    res.statusCode = 416
+    res.setHeader("Content-Range", `bytes */${size}`)
+    res.end()
+
+    return
+  }
+
+  res.statusCode = 206
+  res.setHeader("Content-Range", `bytes ${start}-${end}/${size}`)
+  res.setHeader("Content-Length", end - start + 1)
+  fs.createReadStream(filePath, { start, end }).pipe(res)
+}
+
+/** Serves uploaded media at `/media/` in `vite dev` and `vite preview` (nginx does this in prod). */
+const mediaServer = (): Plugin => ({
+  name: "razzia-media-server",
+  configureServer(server) {
+    server.middlewares.use(serveMedia)
+  },
+  configurePreviewServer(server) {
+    server.middlewares.use(serveMedia)
+  },
+})
 
 const brandingMimeTypes: Record<string, string> = {
   ".json": "application/json",
@@ -37,7 +117,10 @@ const serveBranding = (
   const [relative] = req.url.replace(/^\/branding\//, "").split("?")
   const filePath = path.join(brandingDir, relative)
 
-  if (!filePath.startsWith(brandingDir) || !fs.existsSync(filePath)) {
+  if (
+    !filePath.startsWith(brandingDir + path.sep) ||
+    !fs.existsSync(filePath)
+  ) {
     res.statusCode = 404
     res.end()
 
@@ -77,6 +160,7 @@ export default defineConfig({
     react(),
     tailwindcss(),
     brandingServer(),
+    mediaServer(),
   ],
   resolve: {
     alias: {
@@ -96,6 +180,9 @@ export default defineConfig({
       "/ws": {
         target: "http://localhost:3001",
         ws: true,
+      },
+      "/api": {
+        target: "http://localhost:3001",
       },
     },
   },

--- a/packages/web/vitest.config.ts
+++ b/packages/web/vitest.config.ts
@@ -1,0 +1,22 @@
+import react from "@vitejs/plugin-react"
+import { fileURLToPath } from "url"
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      "@razzia/web": fileURLToPath(new URL("./src", import.meta.url)),
+      "@razzia/common": fileURLToPath(
+        new URL("../common/src", import.meta.url),
+      ),
+      "@razzia/socket": fileURLToPath(
+        new URL("../socket/src", import.meta.url),
+      ),
+    },
+  },
+  test: {
+    environment: "jsdom",
+    setupFiles: ["./src/test/setup.ts"],
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ importers:
         version: 11.0.0
       oxlint:
         specifier: latest
-        version: 1.71.0(oxlint-tsgolint@0.23.0)
+        version: 1.80.0(oxlint-tsgolint@0.23.0)
       oxlint-tsgolint:
         specifier: ^0.23.0
         version: 0.23.0
@@ -45,6 +45,9 @@ importers:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+      vitest:
+        specifier: ^4.1.11
+        version: 4.1.11(@types/node@26.0.1)(jsdom@25.0.1)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))
 
   packages/socket:
     dependencies:
@@ -54,6 +57,15 @@ importers:
       dayjs:
         specifier: ^1.11.21
         version: 1.11.21
+      express:
+        specifier: ^5.2.1
+        version: 5.2.1
+      file-type:
+        specifier: ^22.0.2
+        version: 22.0.2
+      multer:
+        specifier: ^2.2.0
+        version: 2.2.0
       nanoid:
         specifier: ^5.1.16
         version: 5.1.16
@@ -70,15 +82,30 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
+      '@types/express':
+        specifier: ^5.0.6
+        version: 5.0.6
+      '@types/multer':
+        specifier: ^2.2.0
+        version: 2.2.0
       '@types/node':
         specifier: ^26.0.1
         version: 26.0.1
+      '@types/supertest':
+        specifier: ^7.2.1
+        version: 7.2.1
       esbuild:
         specifier: ^0.28.1
         version: 0.28.1
+      supertest:
+        specifier: ^7.2.2
+        version: 7.2.2
       tsx:
         specifier: ^4.22.4
         version: 4.22.4
+      vitest:
+        specifier: ^4.1.11
+        version: 4.1.11(@types/node@26.0.1)(jsdom@25.0.1)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))
 
   packages/web:
     dependencies:
@@ -176,6 +203,15 @@ importers:
       '@tanstack/router-plugin':
         specifier: ^1.168.18
         version: 1.168.18(@tanstack/react-router@1.170.16(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(esbuild@0.28.1)(rolldown@1.1.3)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))
+      '@testing-library/jest-dom':
+        specifier: ^6.6.3
+        version: 6.10.0(@testing-library/dom@10.4.1)
+      '@testing-library/react':
+        specifier: ^16.1.0
+        version: 16.3.3(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@testing-library/user-event':
+        specifier: ^14.5.2
+        version: 14.6.6(@testing-library/dom@10.4.1)
       '@types/node':
         specifier: ^26.0.1
         version: 26.0.1
@@ -188,14 +224,26 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.3
         version: 6.0.3(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))
+      jsdom:
+        specifier: ^25.0.1
+        version: 25.0.1
       typescript:
         specifier: ~6.0.3
         version: 6.0.3
       vite:
         specifier: ^8.1.0
         version: 8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)
+      vitest:
+        specifier: ^4.1.11
+        version: 4.1.11(@types/node@26.0.1)(jsdom@25.0.1)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))
 
 packages:
+
+  '@adobe/css-tools@4.5.0':
+    resolution: {integrity: sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==}
+
+  '@asamuzakjp/css-color@3.2.0':
+    resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
 
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
@@ -267,6 +315,37 @@ packages:
   '@babel/types@7.29.7':
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
+
+  '@borewit/text-codec@0.2.2':
+    resolution: {integrity: sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==}
+
+  '@csstools/color-helpers@5.1.0':
+    resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
+    engines: {node: '>=18'}
+
+  '@csstools/css-calc@2.1.4':
+    resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-color-parser@3.1.0':
+    resolution: {integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5':
+    resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-tokenizer@3.0.4':
+    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
+    engines: {node: '>=18'}
 
   '@dnd-kit/accessibility@3.1.1':
     resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
@@ -551,6 +630,10 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
+  '@noble/hashes@1.8.0':
+    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
+    engines: {node: ^14.21.3 || >=16}
+
   '@oxc-project/types@0.137.0':
     resolution: {integrity: sha512-WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA==}
 
@@ -584,127 +667,130 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@oxlint/binding-android-arm-eabi@1.71.0':
-    resolution: {integrity: sha512-ImGmd1njEg4FEJH03jhRnveEegtO3czCtfptvaHivKAZQIYATbVFBrrzbaYMYv0oJioTnxZAZVSyV+oL7W8S2g==}
+  '@oxlint/binding-android-arm-eabi@1.80.0':
+    resolution: {integrity: sha512-RM3Plj+biQpxa5d1GOOX6ciDlcUROmm4OZ/pLTpitkQt2mJv4jhtY4cbgaetOm5UKWZe05/TGQ6o1Vl8EOHkrA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [android]
 
-  '@oxlint/binding-android-arm64@1.71.0':
-    resolution: {integrity: sha512-4A5BEexBrwY1YFF8Kiq/lp/wQPRG79G3BWIE1FuWaM5MvmpYSd+7ZySVcKkHdwo0UDzdQGddp6pD9mpctMqLnw==}
+  '@oxlint/binding-android-arm64@1.80.0':
+    resolution: {integrity: sha512-YlO5JEf0Yr2bUUlu8O8daVcUxtcGGbcSmyV7E7nSbJbfAdxTE0PFPwgnIlw7wXJaTYjb+qs5hI5q3jxUkI7cAw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@oxlint/binding-darwin-arm64@1.71.0':
-    resolution: {integrity: sha512-9wJA9GJulLwS2usU3CEisI/ESDO1n1z9eyTCvApMDrAkbJ1ve0mORgTMjcWWsKxkzkeZ2N/Gpra5IQE7x8tYgQ==}
+  '@oxlint/binding-darwin-arm64@1.80.0':
+    resolution: {integrity: sha512-BULDOyO3AhsmdWfQeIUCykDt3dd7XZBGLhp1eIh56skRv01O+cNjNPwXMIbeW1x4+pxcln5if72wcRgViVo7PA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@oxlint/binding-darwin-x64@1.71.0':
-    resolution: {integrity: sha512-PlLCjS06V0PeJMAJwzjrExw1sYNW9Gch3JtNlcwwZDXGlTYDuwHNN89zYH8LTXFfgkVtsYvs2nv0FqrzyuFDzg==}
+  '@oxlint/binding-darwin-x64@1.80.0':
+    resolution: {integrity: sha512-YJ4JzLw7N5TDSQFlA0hAQGHvnDZgyypm1yunObVWcWiF9KM7eGCJKYKLgTC2Fi/57OdnBhbj4OkzPGdFQJ6HyA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@oxlint/binding-freebsd-x64@1.71.0':
-    resolution: {integrity: sha512-Lhil7bWre0ncxbUoDoxfS0JzpTz17BRQKW7iwoAUY8GJ66+WwJEfYPCFJ1P0WgVZR5/O/b3Q2pENlHOjeXLOGQ==}
+  '@oxlint/binding-freebsd-x64@1.80.0':
+    resolution: {integrity: sha512-AYUIk5QnL0s8oWAYsREZwkRYy1SupJTXALo93J1TgzHywxQtdM99FecRMQ87MXEdPQ0j1TmEpeeq3fGNkpvMqg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@oxlint/binding-linux-arm-gnueabihf@1.71.0':
-    resolution: {integrity: sha512-Oo9/L58PYD3RC0x05d2upAPLllHytTjHQGsnC06P6Ynn7jKkp5mdImQxXdJ3+FnBaKspNpGogzgVsi6g872LiA==}
+  '@oxlint/binding-linux-arm-gnueabihf@1.80.0':
+    resolution: {integrity: sha512-9hBZVANupQ89W9dXyE0n8doCyaW5pDyGn3y6XlIMPZ+rIKuyqkr3SNUXmVJIhuvUq0NBU3RBiSXXE69l4XI6KA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxlint/binding-linux-arm-musleabihf@1.71.0':
-    resolution: {integrity: sha512-mSHfyfgJrEbyIR29ejaeS50BdPk+GoNPlC1dckpDiUZbJAIel68sjSMdOt4WY0/gva+ECC7FNITQkxMJU+vSBw==}
+  '@oxlint/binding-linux-arm-musleabihf@1.80.0':
+    resolution: {integrity: sha512-SvS2uKqzY+pbfuvAHzH4338R6Zwo805GAwrIMVvK1KxoOWCIjZUdfzTCvilD7z6JK91v011+zYMryabhDo2AsQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxlint/binding-linux-arm64-gnu@1.71.0':
-    resolution: {integrity: sha512-n9yY4M2tiy3aij4AqtlnspzpfdpeT5JQfK2/w2d8oyp5W0FRwOb1dIeX99nORNcxGr08iD9bH8N5XFz3I2iy8w==}
+  '@oxlint/binding-linux-arm64-gnu@1.80.0':
+    resolution: {integrity: sha512-tCLadyqRVL3pQTRPNg7cjXKvcvS4fbyXeQHhKk5BTJ1oftQln5/yIIWbu/Xom/DX41zv2P9QGt6+D/TtQVtY3A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-arm64-musl@1.71.0':
-    resolution: {integrity: sha512-fJZrs5sDZtTaPIOiemRQQmo82Ezy+vOGXemPc4Ok7iVVsYsFa7SlW6Z5XN819VfsqBHRm3NJ3rTdnR8+bJYJdQ==}
+  '@oxlint/binding-linux-arm64-musl@1.80.0':
+    resolution: {integrity: sha512-XfpCNRlOPcLlJl4Bn/FUhjqlR6BVavEykERBf/MV7YA9VZDa5g5znVqYhyviMafcxS9Pe/i/kPvHNO0U6svEHQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@oxlint/binding-linux-ppc64-gnu@1.71.0':
-    resolution: {integrity: sha512-cwl7VKGERIy9p+G+AvZdfy/06q0aHXaTt/mMRReC751iuNYJgqKjB7NydXSS30nBT9vtr2tunciOtrR4fD6FUA==}
+  '@oxlint/binding-linux-ppc64-gnu@1.80.0':
+    resolution: {integrity: sha512-3I4yMwcFG9NeO8ioY6JBBuKsIm5GL/x7MATt1S4tVWaxPu5HcJ+XnLUbcVBTxG8q2Wu56HSj+NmXQiVYb1lp6A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-riscv64-gnu@1.71.0':
-    resolution: {integrity: sha512-eZ8ieVXvzGi8jr7+ybQGPK2STw3mldfxZlgA2738iflfB/rzA69sE6m5rDRpQaxC7dpm745Enlh1Tod0QAk9Gg==}
+  '@oxlint/binding-linux-riscv64-gnu@1.80.0':
+    resolution: {integrity: sha512-E1wAKymkpe1/E8helzBKdm81OBOF+ezxRyXRMEuik3ZpWDER5CPOKZwF66RsdwW98uwZv8UTFremUQtC1CzdJA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-riscv64-musl@1.71.0':
-    resolution: {integrity: sha512-puMDbQYe6+NXwfMusojoA7CXGn2b3utukmd23PQqc1E3XhVCwyZ+FueSMzDYeNgDV2dUfIVXAAKZBcFDeCL6sA==}
+  '@oxlint/binding-linux-riscv64-musl@1.80.0':
+    resolution: {integrity: sha512-+gLRGD4sIo3+VA++iham5UxD9tKSoJ/VOrROCEXIcknrYtQg6iIQgvjN0cpiRF7N6UYC7pJbvHJlDnMge5LRpQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
 
-  '@oxlint/binding-linux-s390x-gnu@1.71.0':
-    resolution: {integrity: sha512-4NJLxBs1ujISCt3L/1FcywLs73PWtJuw+piD6feK2V6h6OS6P7xu9/sWt1DTRLibe6QCzmfZzmM/2HPORoV/Lg==}
+  '@oxlint/binding-linux-s390x-gnu@1.80.0':
+    resolution: {integrity: sha512-aR0PrzHj9leW3NmzBAAP4EzdoBNoJcs9sjnIQPIwyRnBGYrRbXUIpEB5Q39AqK3PLY5JK5uEhDQDiUa1QSAstw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-x64-gnu@1.71.0':
-    resolution: {integrity: sha512-cFDaiR8L3430qp88tfZnvFlt3KotFhR/DlbIL0nHOMMYiG/9Wy4l+6f7t8G8pTa9bd8Lt8+M0y/qjRQ/xcB74g==}
+  '@oxlint/binding-linux-x64-gnu@1.80.0':
+    resolution: {integrity: sha512-vSVh5cSo3Xxs6ghBCcFJlpbkbENzDog1qXtoXLa/HC3aCrR4XO76GZbXmQoCPHnu99nQpdCeC3H9tdNICfDh7A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-x64-musl@1.71.0':
-    resolution: {integrity: sha512-orfixdt76KlpNly9z0PkWBBNfwjKz+JFVLP/7wnVchlKNU9Dpt9InU/ZggeSej6fC7qwHmHNOGlhLnQXcYoGuA==}
+  '@oxlint/binding-linux-x64-musl@1.80.0':
+    resolution: {integrity: sha512-FfzBXpNQ8u7/ZI/p8bl73MeZ508Ax3hxWp3SiJpEFiC+BB9XcXy5FAZHTLKDPSzrUpxQZSZJAVdDmuJp/+HDBQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@oxlint/binding-openharmony-arm64@1.71.0':
-    resolution: {integrity: sha512-9emQu2lAp6yhPB3XuI+++vR+l/o6JR1X+EpxwcumPdQXBWXEPAsquPGL7l158EqU8SebQMXTUa/S5zN98juyHw==}
+  '@oxlint/binding-openharmony-arm64@1.80.0':
+    resolution: {integrity: sha512-zMzbkumtmprCgRwoYNzcB3iC39fXdJIMLMU33KdCjEGLlJGOEt1+LwQ4LF8ndLzAEKVz4BR0y3V6Xrkk3Nm3yA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@oxlint/binding-win32-arm64-msvc@1.71.0':
-    resolution: {integrity: sha512-bd5kI8spYwTm3BILDtGhi73zoup5dw8MlPQNT8YB3BD5UIsjNe3K9/4ctrzQMX4SZMoK5HgzVLkLJzacEXB7fA==}
+  '@oxlint/binding-win32-arm64-msvc@1.80.0':
+    resolution: {integrity: sha512-ib6iRcrXsk4t1fm3iKcwksyWh1ZkZXC/2mEzakl0ai2+6HZunf1WWMZ/xP9EJAvw9g9K4UVTC3NF/+G2qLrbTQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@oxlint/binding-win32-ia32-msvc@1.71.0':
-    resolution: {integrity: sha512-W4HvOHGzVLHcrmFu+bMrJlho+/yrlX5ZNdJZqGe8MEldkQG+RHYhxxad9P4jvWAYFmIqUA5i9DQ8QsJqSU9GIw==}
+  '@oxlint/binding-win32-ia32-msvc@1.80.0':
+    resolution: {integrity: sha512-xhRWBMpLxZvgKAH6+DJZmpP+W8Y8UdQOSU1JfxSWNXsaBaRGW77j+1hCuNHlzj7OH4SPN8fYd1q0o2qrDtoVyw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ia32]
     os: [win32]
 
-  '@oxlint/binding-win32-x64-msvc@1.71.0':
-    resolution: {integrity: sha512-D2kyEIPHk/G/wiZLnwTVC/sVst+T/lKldVOjAFpgTIBUAOlry72e5OiapDbDBF4LfJLkN5ypJb/8Eu6yJzkveQ==}
+  '@oxlint/binding-win32-x64-msvc@1.80.0':
+    resolution: {integrity: sha512-yAnO7lwBYQnz2pcfBPIGQQZWIX5zd5R/1aAKIF3oE+TVj7IhoHcROjOkz3sRDngzqhfPKfFaXqug5j5rE5dn6Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
+
+  '@paralleldrive/cuid2@2.3.1':
+    resolution: {integrity: sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==}
 
   '@radix-ui/number@1.1.2':
     resolution: {integrity: sha512-ceTwaxc4I5IOi97DgCotl3pqiyRGvffcc0oOsE2dQYaJOFIDsDt4VWG6xEbg1QePv9QWausCEIppud/tJ1wNig==}
@@ -1111,6 +1197,9 @@ packages:
   '@socket.io/component-emitter@3.1.2':
     resolution: {integrity: sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@stylistic/eslint-plugin@5.10.0':
     resolution: {integrity: sha512-nPK52ZHvot8Ju/0A4ucSX1dcPV2/1clx0kLcH5wDmrE4naKso7TUC/voUyU1O9OTKTrR6MYip6LP0ogEMQ9jPQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -1269,11 +1358,68 @@ packages:
     resolution: {integrity: sha512-uhOeFyxLcU41HzvrxsGpiWdcMbScY1EDgbZ5K7DVRMYInbLYWAC0EA/kx9wXAoSM8q82bUG2hRl8+EAjE6XAbA==}
     engines: {node: '>=20.19'}
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@6.10.0':
+    resolution: {integrity: sha512-HQwu0KaB2zyT0iLzBL+8CLyZDL3KlZlZJ+2iyc9uCUnlJVskJU/UlPuVCyIPhtukjPQdT2QNoR5nCP5FqTmmDQ==}
+    engines: {node: '>=22', npm: '>=6', yarn: '>=1'}
+    deprecated: Incorrect minor release with breaking changes (Node >=22 and required @testing-library/dom peer). Use 6.9.1 for the 6.x line, or upgrade to 7.0.0.
+    peerDependencies:
+      '@testing-library/dom': '>=10 <11'
+
+  '@testing-library/react@16.3.3':
+    resolution: {integrity: sha512-Uo193NgQbPMz6lrrhtRQQFcMC6Re/ELLFbbuVL30WDlZxlpZf9/lMHTAVxPRLw1q1iu9OJmR1c2BLiENRstdBg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@testing-library/user-event@14.6.6':
+    resolution: {integrity: sha512-Jbs9FpkkIDw8FgSc6kOVsOv8JuuqGAL7J4X1oot77JxAoDlkNn2GRkd0aYRVuQ+pVQAiHWVkE4rX/dkF5fBiCw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
+  '@tokenizer/inflate@0.4.1':
+    resolution: {integrity: sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==}
+    engines: {node: '>=18'}
+
+  '@tokenizer/token@0.3.0':
+    resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
+
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
+
+  '@types/body-parser@1.19.6':
+    resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/connect@3.4.38':
+    resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
+
+  '@types/cookiejar@2.1.5':
+    resolution: {integrity: sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==}
+
   '@types/cors@2.8.19':
     resolution: {integrity: sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/esrecurse@4.3.1':
     resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
@@ -1281,11 +1427,32 @@ packages:
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
+  '@types/express-serve-static-core@5.1.3':
+    resolution: {integrity: sha512-dPfW8NFiOF4wOHc7+N/QSxlY9cfSsenewGbAz8C8U/MULPd/YZ27LvJUIlzaXie7e6Ove9YunJGgC9tbHD2cKw==}
+
+  '@types/express@5.0.6':
+    resolution: {integrity: sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==}
+
+  '@types/http-errors@2.0.5':
+    resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
+  '@types/methods@1.1.4':
+    resolution: {integrity: sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==}
+
+  '@types/multer@2.2.0':
+    resolution: {integrity: sha512-3U1troeqGV8Ntp7Q3klwf4zr23VEoqYVocYXaswm9+8z3O9UHDYAqLxjJ/h550iRADTjKdOdhhasXw6gD6kYtg==}
+
   '@types/node@26.0.1':
     resolution: {integrity: sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==}
+
+  '@types/qs@6.15.1':
+    resolution: {integrity: sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==}
+
+  '@types/range-parser@1.2.7':
+    resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
 
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
@@ -1294,6 +1461,18 @@ packages:
 
   '@types/react@19.2.17':
     resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
+
+  '@types/send@1.2.1':
+    resolution: {integrity: sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==}
+
+  '@types/serve-static@2.2.0':
+    resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==}
+
+  '@types/superagent@8.1.11':
+    resolution: {integrity: sha512-KA7srSW/HENDtOw9DOqaFLgWuMqN9WgjEw62lh9dpvRaZDkhdOkazASd7X7i2eMUYLHa1U37ZttnePsH5zTDHw==}
+
+  '@types/supertest@7.2.1':
+    resolution: {integrity: sha512-4CbBvoYVLHL7+yhbYrZET0vsvuyXTC05aRe7dNQkwMzm56auceoy6Yu3K50uZmwfHna1os3CMSgM/3QVkUtPTw==}
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
@@ -1315,8 +1494,41 @@ packages:
       babel-plugin-react-compiler:
         optional: true
 
+  '@vitest/expect@4.1.11':
+    resolution: {integrity: sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==}
+
+  '@vitest/mocker@4.1.11':
+    resolution: {integrity: sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.11':
+    resolution: {integrity: sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==}
+
+  '@vitest/runner@4.1.11':
+    resolution: {integrity: sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==}
+
+  '@vitest/snapshot@4.1.11':
+    resolution: {integrity: sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==}
+
+  '@vitest/spy@4.1.11':
+    resolution: {integrity: sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==}
+
+  '@vitest/utils@4.1.11':
+    resolution: {integrity: sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==}
+
   accepts@1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
+    engines: {node: '>= 0.6'}
+
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
 
   acorn-jsx@5.3.2:
@@ -1329,16 +1541,48 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
 
   ansis@4.3.1:
     resolution: {integrity: sha512-BJ8/l4R5LRE7hW9WdSuGYrLSHi2ynxeFpDFbH0K/CgNeY/tyhk+vO6TYxXC5r5CpUhNVX310xzPsN/H9lCdfOA==}
     engines: {node: '>=14'}
 
+  append-field@1.0.0:
+    resolution: {integrity: sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==}
+
   aria-hidden@1.2.6:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+
+  aria-query@5.3.2:
+    resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
+    engines: {node: '>= 0.4'}
+
+  asap@2.0.6:
+    resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
   babel-dead-code-elimination@1.0.12:
     resolution: {integrity: sha512-GERT7L2TiYcYDtYk1IpD+ASAYXjKbLTDPhBtYj7X1NuRMDTMtAx9kyBenub1Ev41lo91OHCKdmP+egTDmfQ7Ig==}
@@ -1356,6 +1600,10 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  body-parser@2.3.0:
+    resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
+    engines: {node: '>=18'}
+
   brace-expansion@5.0.6:
     resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
@@ -1365,8 +1613,31 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  buffer-from@1.1.2:
+    resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
+  busboy@1.6.0:
+    resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
+    engines: {node: '>=10.16.0'}
+
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
+
   caniuse-lite@1.0.30001799:
     resolution: {integrity: sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chokidar@5.0.0:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
@@ -1376,15 +1647,45 @@ packages:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
 
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
+  component-emitter@1.3.1:
+    resolution: {integrity: sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==}
+
+  concat-stream@2.0.0:
+    resolution: {integrity: sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==}
+    engines: {'0': node >= 6.0}
+
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
+  content-type@2.1.0:
+    resolution: {integrity: sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==}
+    engines: {node: '>=18'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   cookie-es@3.1.1:
     resolution: {integrity: sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==}
 
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
+
+  cookiejar@2.1.4:
+    resolution: {integrity: sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==}
 
   cors@2.8.6:
     resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
@@ -1394,8 +1695,19 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
+  cssstyle@4.6.0:
+    resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
+    engines: {node: '>=18'}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  data-urls@5.0.0:
+    resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
+    engines: {node: '>=18'}
 
   dayjs@1.11.21:
     resolution: {integrity: sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==}
@@ -1409,8 +1721,23 @@ packages:
       supports-color:
         optional: true
 
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
@@ -1419,9 +1746,18 @@ packages:
   detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
 
+  dezalgo@1.0.4:
+    resolution: {integrity: sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==}
+
   diff@8.0.4:
     resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
     engines: {node: '>=0.3.1'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
   dotenv-cli@11.0.0:
     resolution: {integrity: sha512-r5pA8idbk7GFWuHEU7trSTflWcdBpQEK+Aw17UrSHjS6CReuhrrPcyC3zcQBPQvhArRHnBo/h6eLH1fkCvNlww==}
@@ -1439,8 +1775,19 @@ packages:
     resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
     engines: {node: '>=12'}
 
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
   electron-to-chromium@1.5.379:
     resolution: {integrity: sha512-v/qV5aV5EUA2pGilzUCq5/eyOloZAqDZBu9UMBIzgPpLlprjSR6zswsWBTv0KpqxLGUAZEwhO95ZCt7srymNVA==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
 
   engine.io-client@6.6.6:
     resolution: {integrity: sha512-iY6QdftLQ9pyiPoX082bpf/u1UewnOaJrtJIF9T0++QB34lZrj0uP+Q/bj8AlUsAxqhnkTV2BS8SBZSxOmoV5Q==}
@@ -1457,6 +1804,29 @@ packages:
     resolution: {integrity: sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==}
     engines: {node: '>=10.13.0'}
 
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-module-lexer@2.3.2:
+    resolution: {integrity: sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==}
+
+  es-object-atoms@1.1.2:
+    resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
+
   esbuild@0.28.1:
     resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
     engines: {node: '>=18'}
@@ -1465,6 +1835,9 @@ packages:
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -1516,9 +1889,24 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -1528,6 +1916,9 @@ packages:
 
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fast-safe-stringify@2.1.1:
+    resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -1542,6 +1933,14 @@ packages:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
 
+  file-type@22.0.2:
+    resolution: {integrity: sha512-0H8TsCUGBLx+V5adH3EY52hTAcyLKbV1D4gq5cIOJ6DnQAHeV9Z2Hhuc5CoBX4YmvB2oL+JIC84z0qO7JsCoNw==}
+    engines: {node: '>=22'}
+
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
@@ -1552,6 +1951,18 @@ packages:
 
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
+
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
+    engines: {node: '>= 6'}
+
+  formidable@3.5.4:
+    resolution: {integrity: sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==}
+    engines: {node: '>=14.0.0'}
+
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
 
   framer-motion@12.42.0:
     resolution: {integrity: sha512-wp7EJnfWaaEScVygKv3e20udoRz+LbtxScsuTkakAxfXmt+ReC6WyPW2nINRAGvd+hG9odwcjBLyOTPjH5pBRA==}
@@ -1567,18 +1978,33 @@ packages:
       react-dom:
         optional: true
 
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
 
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
   get-nonce@1.0.1:
     resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
     engines: {node: '>=6'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
 
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
@@ -1589,14 +2015,46 @@ packages:
     peerDependencies:
       csstype: ^3.0.10
 
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
+    engines: {node: '>= 0.4'}
 
   howler@2.2.4:
     resolution: {integrity: sha512-iARIBPgcQrwtEr+tALF+rapJ8qSc+Set2GJQl7xT1MQzWaVkFebdJhR3alVlSiUf5U7nAANKuj3aWpwerocD5w==}
 
+  html-encoding-sniffer@4.0.0:
+    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
+    engines: {node: '>=18'}
+
   html-parse-stringify@3.0.1:
     resolution: {integrity: sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
 
   i18next-browser-languagedetector@8.2.1:
     resolution: {integrity: sha512-bZg8+4bdmaOiApD7N7BPT9W8MLZG+nPTOFlLiJiT8uzKXFjhxw4v2ierCXOwB5sFDMtuA5G4kgYZ0AznZxQ/cw==}
@@ -1609,6 +2067,17 @@ packages:
       typescript:
         optional: true
 
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
+  iconv-lite@0.7.3:
+    resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
+    engines: {node: '>=0.10.0'}
+
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -1617,6 +2086,17 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -1624,6 +2104,12 @@ packages:
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
+
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
   isbot@5.1.44:
     resolution: {integrity: sha512-PGEHtwMnKbZpeSEXW2Utx+/JWed7dp6DiH0WWg33vGSDA7RUvpUeJSVlLrVkQ1RCpvDOUc/eH9ql7VsdbBZ8pA==}
@@ -1638,6 +2124,15 @@ packages:
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  jsdom@25.0.1:
+    resolution: {integrity: sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      canvas: ^2.11.2
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -1743,6 +2238,9 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -1751,16 +2249,57 @@ packages:
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  media-typer@0.3.0:
+    resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
+    engines: {node: '>= 0.6'}
+
+  media-typer@1.1.1:
+    resolution: {integrity: sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==}
+    engines: {node: '>= 0.8'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
+
+  methods@1.1.2:
+    resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
+    engines: {node: '>= 0.6'}
 
   mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
 
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
+
+  mime@2.6.0:
+    resolution: {integrity: sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==}
+    engines: {node: '>=4.0.0'}
+    hasBin: true
+
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
 
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
@@ -1792,6 +2331,10 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  multer@2.2.0:
+    resolution: {integrity: sha512-6rdyFg2kLrMh9Jee7/BMPuV9lEAd7lLW2YUpF9/YxR7njyoUwwQ0ZPh3TaIY50Sw6vlyD2HW3wGOkTS4P79xrQ==}
+    engines: {node: '>= 10.16.0'}
+
   nanoid@3.3.15:
     resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -1809,13 +2352,35 @@ packages:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
     engines: {node: '>= 0.6'}
 
+  negotiator@1.1.0:
+    resolution: {integrity: sha512-NMPBRMJgiQHjbd8phG3Vebdx4kZ1H121rbl5IkMqeOsahptB9BKo/d7oJ3zTXqTgagn2bWlNSXkh0QUGM31RYg==}
+    engines: {node: '>=18'}
+
   node-releases@2.0.50:
     resolution: {integrity: sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==}
     engines: {node: '>=18'}
 
+  nwsapi@2.2.24:
+    resolution: {integrity: sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
+  obug@2.1.4:
+    resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
+    engines: {node: '>=12.20.0'}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -1825,12 +2390,12 @@ packages:
     resolution: {integrity: sha512-3mBv3CoPbh8dFbzfDGIWa2ytZjn2v+3EX4aKRXjIhsoGFzG8GCjfRirz3rwZf1wYbZzsNLTSgpw8VjQuWdp/jA==}
     hasBin: true
 
-  oxlint@1.71.0:
-    resolution: {integrity: sha512-U1m1X+C0vDj7DC1e13IoZULzEcPczE7UOMTs8VlZGHUEIUaSTZKo5qkPsQEfzpgnQ29Pea/w3Xntk62UCecxZw==}
+  oxlint@1.80.0:
+    resolution: {integrity: sha512-5nTiSps4qdbCWLbxzuO00alHkEO2exR9YMN/ig6QXWrLsYSG0KaObOAM+l6oU2LcKPWoSAGYbkZIGEu1ViiWKA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
-      oxlint-tsgolint: '>=0.22.1'
+      oxlint-tsgolint: '>=7.0.2001'
       vite-plus: '*'
     peerDependenciesMeta:
       oxlint-tsgolint:
@@ -1846,6 +2411,13 @@ packages:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
 
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -1853,6 +2425,9 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -1932,6 +2507,14 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -1940,6 +2523,18 @@ packages:
     resolution: {integrity: sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  qs@6.15.3:
+    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
+    engines: {node: '>=0.6'}
+
+  range-parser@1.3.0:
+    resolution: {integrity: sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   react-confetti@6.4.0:
     resolution: {integrity: sha512-5MdGUcqxrTU26I2EU7ltkWPwxvucQTuqMm8dUz72z2YMqTD6s9vMcDUysk7n9jnC+lXuCPeJJ7Knf98VEYE9Rg==}
@@ -1975,6 +2570,9 @@ packages:
       typescript:
         optional: true
 
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
   react-remove-scroll-bar@2.3.8:
     resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
     engines: {node: '>=10'}
@@ -2009,14 +2607,42 @@ packages:
     resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
     engines: {node: '>=0.10.0'}
 
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
+
   readdirp@5.0.0:
     resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
     engines: {node: '>= 20.19.0'}
+
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
 
   rolldown@1.1.3:
     resolution: {integrity: sha512-1F1eEtUBtFvcGm1HQ9TiUIUHPQG7mSAODrhIzjxoUEFuo8OcbrGLiVLkevNgj84TE4lnHvnumwFjhJO5Eu135g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
+
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
+  rrweb-cssom@0.7.1:
+    resolution: {integrity: sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==}
+
+  rrweb-cssom@0.8.0:
+    resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -2024,6 +2650,10 @@ packages:
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
+
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
 
   seroval-plugins@1.5.4:
     resolution: {integrity: sha512-S0xQPhUTefAhNvNWFg0c1J8qJArHt5KdtJ/cFAofo06KD1MVSeFWyl4iiu+ApDIuw0WhjpOfCdgConOfAnLgkw==}
@@ -2035,6 +2665,13 @@ packages:
     resolution: {integrity: sha512-46uFvgrXTVxZcUorgSSRZ4y+ieqLLQRMlG4bnCZKW3qI6BZm7Rg4ntMW4p1mILEEBZWrFlcpp0AyIIlM6jD9iw==}
     engines: {node: '>=10'}
 
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
@@ -2042,6 +2679,25 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.1:
+    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
+    engines: {node: '>= 0.4'}
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
   socket.io-adapter@2.5.8:
     resolution: {integrity: sha512-6Oy52pbg+kvdCVvjcN+FnY7BvxZ7cIHNScbvztT/It5d0vbwoJoVZmF2gjJmnV0/4WlXRfG15zc45ySk9Ah8bw==}
@@ -2062,6 +2718,42 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
+
+  std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
+
+  streamsearch@1.1.0:
+    resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
+    engines: {node: '>=10.0.0'}
+
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
+
+  strtok3@10.3.5:
+    resolution: {integrity: sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==}
+    engines: {node: '>=18'}
+
+  superagent@10.3.0:
+    resolution: {integrity: sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==}
+    engines: {node: '>=14.18.0'}
+
+  supertest@7.2.2:
+    resolution: {integrity: sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==}
+    engines: {node: '>=14.18.0'}
+
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   tailwind-merge@3.6.0:
     resolution: {integrity: sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==}
 
@@ -2072,9 +2764,43 @@ packages:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.3.0:
+    resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.1:
+    resolution: {integrity: sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==}
+    engines: {node: '>=14.0.0'}
+
+  tldts-core@6.1.86:
+    resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
+
+  tldts@6.1.86:
+    resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
+    hasBin: true
+
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
+  token-types@6.1.2:
+    resolution: {integrity: sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==}
+    engines: {node: '>=14.16'}
+
+  tough-cookie@5.1.2:
+    resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
+    engines: {node: '>=16'}
+
+  tr46@5.1.1:
+    resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
+    engines: {node: '>=18'}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -2091,13 +2817,32 @@ packages:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
 
+  type-is@1.6.18:
+    resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
+    engines: {node: '>= 0.6'}
+
+  type-is@2.1.0:
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    engines: {node: '>= 18'}
+
+  typedarray@0.0.6:
+    resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
+
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
+  uint8array-extras@1.5.0:
+    resolution: {integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==}
+    engines: {node: '>=18'}
+
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
+
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
 
   unplugin@3.2.0:
     resolution: {integrity: sha512-6nGlT7EHsS+tTcTdAkYFqXIUwDrMJyJvHFNYGSr4x2/2ySIcV4f5e1RAJUeDyfOJPR8TF0auE8l+82PLhKjqsA==}
@@ -2171,6 +2916,9 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
   uuid@14.0.1:
     resolution: {integrity: sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==}
     hasBin: true
@@ -2222,21 +2970,91 @@ packages:
       yaml:
         optional: true
 
+  vitest@4.1.11:
+    resolution: {integrity: sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.11
+      '@vitest/browser-preview': 4.1.11
+      '@vitest/browser-webdriverio': 4.1.11
+      '@vitest/coverage-istanbul': 4.1.11
+      '@vitest/coverage-v8': 4.1.11
+      '@vitest/ui': 4.1.11
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   void-elements@3.1.0:
     resolution: {integrity: sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==}
     engines: {node: '>=0.10.0'}
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+
   webpack-virtual-modules@0.6.2:
     resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
+
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
+  whatwg-url@14.2.0:
+    resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
+    engines: {node: '>=18'}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
     hasBin: true
 
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
   ws@8.21.0:
     resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
@@ -2249,6 +3067,13 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   xmlhttprequest-ssl@2.1.2:
     resolution: {integrity: sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==}
@@ -2283,6 +3108,16 @@ packages:
         optional: true
 
 snapshots:
+
+  '@adobe/css-tools@4.5.0': {}
+
+  '@asamuzakjp/css-color@3.2.0':
+    dependencies:
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      lru-cache: 10.4.3
 
   '@babel/code-frame@7.29.7':
     dependencies:
@@ -2385,6 +3220,28 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
+
+  '@borewit/text-codec@0.2.2': {}
+
+  '@csstools/color-helpers@5.1.0': {}
+
+  '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/color-helpers': 5.1.0
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-tokenizer@3.0.4': {}
 
   '@dnd-kit/accessibility@3.1.1(react@19.2.7)':
     dependencies:
@@ -2603,6 +3460,8 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
+  '@noble/hashes@1.8.0': {}
+
   '@oxc-project/types@0.137.0': {}
 
   '@oxlint-tsgolint/darwin-arm64@0.23.0':
@@ -2623,62 +3482,66 @@ snapshots:
   '@oxlint-tsgolint/win32-x64@0.23.0':
     optional: true
 
-  '@oxlint/binding-android-arm-eabi@1.71.0':
+  '@oxlint/binding-android-arm-eabi@1.80.0':
     optional: true
 
-  '@oxlint/binding-android-arm64@1.71.0':
+  '@oxlint/binding-android-arm64@1.80.0':
     optional: true
 
-  '@oxlint/binding-darwin-arm64@1.71.0':
+  '@oxlint/binding-darwin-arm64@1.80.0':
     optional: true
 
-  '@oxlint/binding-darwin-x64@1.71.0':
+  '@oxlint/binding-darwin-x64@1.80.0':
     optional: true
 
-  '@oxlint/binding-freebsd-x64@1.71.0':
+  '@oxlint/binding-freebsd-x64@1.80.0':
     optional: true
 
-  '@oxlint/binding-linux-arm-gnueabihf@1.71.0':
+  '@oxlint/binding-linux-arm-gnueabihf@1.80.0':
     optional: true
 
-  '@oxlint/binding-linux-arm-musleabihf@1.71.0':
+  '@oxlint/binding-linux-arm-musleabihf@1.80.0':
     optional: true
 
-  '@oxlint/binding-linux-arm64-gnu@1.71.0':
+  '@oxlint/binding-linux-arm64-gnu@1.80.0':
     optional: true
 
-  '@oxlint/binding-linux-arm64-musl@1.71.0':
+  '@oxlint/binding-linux-arm64-musl@1.80.0':
     optional: true
 
-  '@oxlint/binding-linux-ppc64-gnu@1.71.0':
+  '@oxlint/binding-linux-ppc64-gnu@1.80.0':
     optional: true
 
-  '@oxlint/binding-linux-riscv64-gnu@1.71.0':
+  '@oxlint/binding-linux-riscv64-gnu@1.80.0':
     optional: true
 
-  '@oxlint/binding-linux-riscv64-musl@1.71.0':
+  '@oxlint/binding-linux-riscv64-musl@1.80.0':
     optional: true
 
-  '@oxlint/binding-linux-s390x-gnu@1.71.0':
+  '@oxlint/binding-linux-s390x-gnu@1.80.0':
     optional: true
 
-  '@oxlint/binding-linux-x64-gnu@1.71.0':
+  '@oxlint/binding-linux-x64-gnu@1.80.0':
     optional: true
 
-  '@oxlint/binding-linux-x64-musl@1.71.0':
+  '@oxlint/binding-linux-x64-musl@1.80.0':
     optional: true
 
-  '@oxlint/binding-openharmony-arm64@1.71.0':
+  '@oxlint/binding-openharmony-arm64@1.80.0':
     optional: true
 
-  '@oxlint/binding-win32-arm64-msvc@1.71.0':
+  '@oxlint/binding-win32-arm64-msvc@1.80.0':
     optional: true
 
-  '@oxlint/binding-win32-ia32-msvc@1.71.0':
+  '@oxlint/binding-win32-ia32-msvc@1.80.0':
     optional: true
 
-  '@oxlint/binding-win32-x64-msvc@1.71.0':
+  '@oxlint/binding-win32-x64-msvc@1.80.0':
     optional: true
+
+  '@paralleldrive/cuid2@2.3.1':
+    dependencies:
+      '@noble/hashes': 1.8.0
 
   '@radix-ui/number@1.1.2': {}
 
@@ -3011,6 +3874,8 @@ snapshots:
 
   '@socket.io/component-emitter@3.1.2': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@stylistic/eslint-plugin@5.10.0(eslint@10.3.0(jiti@2.7.0))':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@10.3.0(jiti@2.7.0))
@@ -3168,24 +4033,113 @@ snapshots:
 
   '@tanstack/virtual-file-routes@1.162.0': {}
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/runtime': 7.29.7
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.10.0(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@adobe/css-tools': 4.5.0
+      '@testing-library/dom': 10.4.1
+      aria-query: 5.3.2
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
+  '@testing-library/react@16.3.3(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@testing-library/dom': 10.4.1
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@testing-library/user-event@14.6.6(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+
+  '@tokenizer/inflate@0.4.1':
+    dependencies:
+      debug: 4.4.3
+      token-types: 6.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@tokenizer/token@0.3.0': {}
+
   '@tybys/wasm-util@0.10.3':
     dependencies:
       tslib: 2.8.1
     optional: true
 
+  '@types/aria-query@5.0.4': {}
+
+  '@types/body-parser@1.19.6':
+    dependencies:
+      '@types/connect': 3.4.38
+      '@types/node': 26.0.1
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/connect@3.4.38':
+    dependencies:
+      '@types/node': 26.0.1
+
+  '@types/cookiejar@2.1.5': {}
+
   '@types/cors@2.8.19':
     dependencies:
       '@types/node': 26.0.1
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/esrecurse@4.3.1': {}
 
   '@types/estree@1.0.9': {}
 
+  '@types/express-serve-static-core@5.1.3':
+    dependencies:
+      '@types/node': 26.0.1
+      '@types/qs': 6.15.1
+      '@types/range-parser': 1.2.7
+      '@types/send': 1.2.1
+
+  '@types/express@5.0.6':
+    dependencies:
+      '@types/body-parser': 1.19.6
+      '@types/express-serve-static-core': 5.1.3
+      '@types/serve-static': 2.2.0
+
+  '@types/http-errors@2.0.5': {}
+
   '@types/json-schema@7.0.15': {}
+
+  '@types/methods@1.1.4': {}
+
+  '@types/multer@2.2.0':
+    dependencies:
+      '@types/express': 5.0.6
 
   '@types/node@26.0.1':
     dependencies:
       undici-types: 8.3.0
+
+  '@types/qs@6.15.1': {}
+
+  '@types/range-parser@1.2.7': {}
 
   '@types/react-dom@19.2.3(@types/react@19.2.17)':
     dependencies:
@@ -3194,6 +4148,27 @@ snapshots:
   '@types/react@19.2.17':
     dependencies:
       csstype: 3.2.3
+
+  '@types/send@1.2.1':
+    dependencies:
+      '@types/node': 26.0.1
+
+  '@types/serve-static@2.2.0':
+    dependencies:
+      '@types/http-errors': 2.0.5
+      '@types/node': 26.0.1
+
+  '@types/superagent@8.1.11':
+    dependencies:
+      '@types/cookiejar': 2.1.5
+      '@types/methods': 1.1.4
+      '@types/node': 26.0.1
+      form-data: 4.0.6
+
+  '@types/supertest@7.2.1':
+    dependencies:
+      '@types/methods': 1.1.4
+      '@types/superagent': 8.1.11
 
   '@types/ws@8.18.1':
     dependencies:
@@ -3206,16 +4181,64 @@ snapshots:
       '@rolldown/pluginutils': 1.0.1
       vite: 8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)
 
+  '@vitest/expect@4.1.11':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.11
+      '@vitest/utils': 4.1.11
+      chai: 6.2.2
+      tinyrainbow: 3.1.1
+
+  '@vitest/mocker@4.1.11(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))':
+    dependencies:
+      '@vitest/spy': 4.1.11
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)
+
+  '@vitest/pretty-format@4.1.11':
+    dependencies:
+      tinyrainbow: 3.1.1
+
+  '@vitest/runner@4.1.11':
+    dependencies:
+      '@vitest/utils': 4.1.11
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.11':
+    dependencies:
+      '@vitest/pretty-format': 4.1.11
+      '@vitest/utils': 4.1.11
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.11': {}
+
+  '@vitest/utils@4.1.11':
+    dependencies:
+      '@vitest/pretty-format': 4.1.11
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.1
+
   accepts@1.3.8:
     dependencies:
       mime-types: 2.1.35
       negotiator: 0.6.3
+
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.1.0
 
   acorn-jsx@5.3.2(acorn@8.17.0):
     dependencies:
       acorn: 8.17.0
 
   acorn@8.17.0: {}
+
+  agent-base@7.1.4: {}
 
   ajv@6.15.0:
     dependencies:
@@ -3224,11 +4247,29 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
+  ansi-regex@5.0.1: {}
+
+  ansi-styles@5.2.0: {}
+
   ansis@4.3.1: {}
+
+  append-field@1.0.0: {}
 
   aria-hidden@1.2.6:
     dependencies:
       tslib: 2.8.1
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
+
+  aria-query@5.3.2: {}
+
+  asap@2.0.6: {}
+
+  assertion-error@2.0.1: {}
+
+  asynckit@0.4.0: {}
 
   babel-dead-code-elimination@1.0.12:
     dependencies:
@@ -3245,6 +4286,20 @@ snapshots:
 
   baseline-browser-mapping@2.10.40: {}
 
+  body-parser@2.3.0:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 2.1.0
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.3
+      on-finished: 2.4.1
+      qs: 6.15.3
+      raw-body: 3.0.2
+      type-is: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.4
@@ -3257,7 +4312,27 @@ snapshots:
       node-releases: 2.0.50
       update-browserslist-db: 1.2.3(browserslist@4.28.4)
 
+  buffer-from@1.1.2: {}
+
+  busboy@1.6.0:
+    dependencies:
+      streamsearch: 1.1.0
+
+  bytes@3.1.2: {}
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
+
   caniuse-lite@1.0.30001799: {}
+
+  chai@6.2.2: {}
 
   chokidar@5.0.0:
     dependencies:
@@ -3265,11 +4340,34 @@ snapshots:
 
   clsx@2.1.1: {}
 
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
+  component-emitter@1.3.1: {}
+
+  concat-stream@2.0.0:
+    dependencies:
+      buffer-from: 1.1.2
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+      typedarray: 0.0.6
+
+  content-disposition@1.1.0: {}
+
+  content-type@1.0.5: {}
+
+  content-type@2.1.0: {}
+
   convert-source-map@2.0.0: {}
 
   cookie-es@3.1.1: {}
 
+  cookie-signature@1.2.2: {}
+
   cookie@0.7.2: {}
+
+  cookiejar@2.1.4: {}
 
   cors@2.8.6:
     dependencies:
@@ -3282,7 +4380,19 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css.escape@1.5.1: {}
+
+  cssstyle@4.6.0:
+    dependencies:
+      '@asamuzakjp/css-color': 3.2.0
+      rrweb-cssom: 0.8.0
+
   csstype@3.2.3: {}
+
+  data-urls@5.0.0:
+    dependencies:
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
 
   dayjs@1.11.21: {}
 
@@ -3290,13 +4400,30 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decimal.js@10.6.0: {}
+
   deep-is@0.1.4: {}
+
+  delayed-stream@1.0.0: {}
+
+  depd@2.0.0: {}
+
+  dequal@2.0.3: {}
 
   detect-libc@2.1.2: {}
 
   detect-node-es@1.1.0: {}
 
+  dezalgo@1.0.4:
+    dependencies:
+      asap: 2.0.6
+      wrappy: 1.0.2
+
   diff@8.0.4: {}
+
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
 
   dotenv-cli@11.0.0:
     dependencies:
@@ -3313,7 +4440,17 @@ snapshots:
 
   dotenv@17.4.2: {}
 
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  ee-first@1.1.1: {}
+
   electron-to-chromium@1.5.379: {}
+
+  encodeurl@2.0.0: {}
 
   engine.io-client@6.6.6:
     dependencies:
@@ -3351,6 +4488,25 @@ snapshots:
       graceful-fs: 4.2.11
       tapable: 2.3.3
 
+  entities@6.0.1: {}
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
+  es-module-lexer@2.3.2: {}
+
+  es-object-atoms@1.1.2:
+    dependencies:
+      es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.4
+
   esbuild@0.28.1:
     optionalDependencies:
       '@esbuild/aix-ppc64': 0.28.1
@@ -3381,6 +4537,8 @@ snapshots:
       '@esbuild/win32-x64': 0.28.1
 
   escalade@3.2.0: {}
+
+  escape-html@1.0.3: {}
 
   escape-string-regexp@4.0.0: {}
 
@@ -3456,13 +4614,56 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
   esutils@2.0.3: {}
+
+  etag@1.8.1: {}
+
+  expect-type@1.4.0: {}
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.3.0
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.3
+      range-parser: 1.3.0
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.1.0
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   fast-deep-equal@3.1.3: {}
 
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
+
+  fast-safe-stringify@2.1.1: {}
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -3471,6 +4672,26 @@ snapshots:
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
+
+  file-type@22.0.2:
+    dependencies:
+      '@tokenizer/inflate': 0.4.1
+      strtok3: 10.3.5
+      token-types: 6.1.2
+      uint8array-extras: 1.5.0
+    transitivePeerDependencies:
+      - supports-color
+
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   find-up@5.0.0:
     dependencies:
@@ -3484,6 +4705,22 @@ snapshots:
 
   flatted@3.4.2: {}
 
+  form-data@4.0.6:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.4
+      mime-types: 2.1.35
+
+  formidable@3.5.4:
+    dependencies:
+      '@paralleldrive/cuid2': 2.3.1
+      dezalgo: 1.0.4
+      once: 1.4.0
+
+  forwarded@0.2.0: {}
+
   framer-motion@12.42.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       motion-dom: 12.42.0
@@ -3493,12 +4730,34 @@ snapshots:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
+  fresh@2.0.0: {}
+
   fsevents@2.3.3:
     optional: true
 
+  function-bind@1.1.2: {}
+
   gensync@1.0.0-beta.2: {}
 
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.2
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.4
+      math-intrinsics: 1.1.0
+
   get-nonce@1.0.1: {}
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.2
 
   glob-parent@6.0.2:
     dependencies:
@@ -3508,13 +4767,51 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
+  gopd@1.2.0: {}
+
   graceful-fs@4.2.11: {}
 
+  has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
+
+  hasown@2.0.4:
+    dependencies:
+      function-bind: 1.1.2
+
   howler@2.2.4: {}
+
+  html-encoding-sniffer@4.0.0:
+    dependencies:
+      whatwg-encoding: 3.1.1
 
   html-parse-stringify@3.0.1:
     dependencies:
       void-elements: 3.1.0
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   i18next-browser-languagedetector@8.2.1:
     dependencies:
@@ -3524,15 +4821,35 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  iconv-lite@0.7.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  ieee754@1.2.1: {}
+
   ignore@5.3.2: {}
 
   imurmurhash@0.1.4: {}
+
+  indent-string@4.0.0: {}
+
+  inherits@2.0.4: {}
+
+  ipaddr.js@1.9.1: {}
 
   is-extglob@2.1.1: {}
 
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
+
+  is-potential-custom-element-name@1.0.1: {}
+
+  is-promise@4.0.0: {}
 
   isbot@5.1.44: {}
 
@@ -3541,6 +4858,34 @@ snapshots:
   jiti@2.7.0: {}
 
   js-tokens@4.0.0: {}
+
+  jsdom@25.0.1:
+    dependencies:
+      cssstyle: 4.6.0
+      data-urls: 5.0.0
+      decimal.js: 10.6.0
+      form-data: 4.0.6
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.24
+      parse5: 7.3.0
+      rrweb-cssom: 0.7.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 5.1.2
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+      ws: 8.21.0
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   jsesc@3.1.0: {}
 
@@ -3614,6 +4959,8 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
+  lru-cache@10.4.3: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -3622,15 +4969,37 @@ snapshots:
     dependencies:
       react: 19.2.7
 
+  lz-string@1.5.0: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  math-intrinsics@1.1.0: {}
+
+  media-typer@0.3.0: {}
+
+  media-typer@1.1.1: {}
+
+  merge-descriptors@2.0.0: {}
+
+  methods@1.1.2: {}
+
   mime-db@1.52.0: {}
+
+  mime-db@1.54.0: {}
 
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
+
+  mime@2.6.0: {}
+
+  min-indent@1.0.1: {}
 
   minimatch@10.2.5:
     dependencies:
@@ -3654,6 +5023,13 @@ snapshots:
 
   ms@2.1.3: {}
 
+  multer@2.2.0:
+    dependencies:
+      append-field: 1.0.0
+      busboy: 1.6.0
+      concat-stream: 2.0.0
+      type-is: 1.6.18
+
   nanoid@3.3.15: {}
 
   nanoid@5.1.16: {}
@@ -3662,9 +5038,27 @@ snapshots:
 
   negotiator@0.6.3: {}
 
+  negotiator@1.1.0:
+    dependencies:
+      content-type: 2.1.0
+
   node-releases@2.0.50: {}
 
+  nwsapi@2.2.24: {}
+
   object-assign@4.1.1: {}
+
+  object-inspect@1.13.4: {}
+
+  obug@2.1.4: {}
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
 
   optionator@0.9.4:
     dependencies:
@@ -3684,27 +5078,27 @@ snapshots:
       '@oxlint-tsgolint/win32-arm64': 0.23.0
       '@oxlint-tsgolint/win32-x64': 0.23.0
 
-  oxlint@1.71.0(oxlint-tsgolint@0.23.0):
+  oxlint@1.80.0(oxlint-tsgolint@0.23.0):
     optionalDependencies:
-      '@oxlint/binding-android-arm-eabi': 1.71.0
-      '@oxlint/binding-android-arm64': 1.71.0
-      '@oxlint/binding-darwin-arm64': 1.71.0
-      '@oxlint/binding-darwin-x64': 1.71.0
-      '@oxlint/binding-freebsd-x64': 1.71.0
-      '@oxlint/binding-linux-arm-gnueabihf': 1.71.0
-      '@oxlint/binding-linux-arm-musleabihf': 1.71.0
-      '@oxlint/binding-linux-arm64-gnu': 1.71.0
-      '@oxlint/binding-linux-arm64-musl': 1.71.0
-      '@oxlint/binding-linux-ppc64-gnu': 1.71.0
-      '@oxlint/binding-linux-riscv64-gnu': 1.71.0
-      '@oxlint/binding-linux-riscv64-musl': 1.71.0
-      '@oxlint/binding-linux-s390x-gnu': 1.71.0
-      '@oxlint/binding-linux-x64-gnu': 1.71.0
-      '@oxlint/binding-linux-x64-musl': 1.71.0
-      '@oxlint/binding-openharmony-arm64': 1.71.0
-      '@oxlint/binding-win32-arm64-msvc': 1.71.0
-      '@oxlint/binding-win32-ia32-msvc': 1.71.0
-      '@oxlint/binding-win32-x64-msvc': 1.71.0
+      '@oxlint/binding-android-arm-eabi': 1.80.0
+      '@oxlint/binding-android-arm64': 1.80.0
+      '@oxlint/binding-darwin-arm64': 1.80.0
+      '@oxlint/binding-darwin-x64': 1.80.0
+      '@oxlint/binding-freebsd-x64': 1.80.0
+      '@oxlint/binding-linux-arm-gnueabihf': 1.80.0
+      '@oxlint/binding-linux-arm-musleabihf': 1.80.0
+      '@oxlint/binding-linux-arm64-gnu': 1.80.0
+      '@oxlint/binding-linux-arm64-musl': 1.80.0
+      '@oxlint/binding-linux-ppc64-gnu': 1.80.0
+      '@oxlint/binding-linux-riscv64-gnu': 1.80.0
+      '@oxlint/binding-linux-riscv64-musl': 1.80.0
+      '@oxlint/binding-linux-s390x-gnu': 1.80.0
+      '@oxlint/binding-linux-x64-gnu': 1.80.0
+      '@oxlint/binding-linux-x64-musl': 1.80.0
+      '@oxlint/binding-openharmony-arm64': 1.80.0
+      '@oxlint/binding-win32-arm64-msvc': 1.80.0
+      '@oxlint/binding-win32-ia32-msvc': 1.80.0
+      '@oxlint/binding-win32-x64-msvc': 1.80.0
       oxlint-tsgolint: 0.23.0
 
   p-limit@3.1.0:
@@ -3715,9 +5109,17 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
+
+  parseurl@1.3.3: {}
+
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
+
+  path-to-regexp@8.4.2: {}
 
   pathe@2.0.3: {}
 
@@ -3739,11 +5141,36 @@ snapshots:
 
   prettier@3.8.5: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
   punycode@2.3.1: {}
 
   qrcode.react@4.2.0(react@19.2.7):
     dependencies:
       react: 19.2.7
+
+  qs@6.15.3:
+    dependencies:
+      es-define-property: 1.0.1
+      side-channel: 1.1.1
+
+  range-parser@1.3.0: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.3
+      unpipe: 1.0.0
 
   react-confetti@6.4.0(react@19.2.7):
     dependencies:
@@ -3772,6 +5199,8 @@ snapshots:
     optionalDependencies:
       react-dom: 19.2.7(react@19.2.7)
       typescript: 6.0.3
+
+  react-is@17.0.2: {}
 
   react-remove-scroll-bar@2.3.8(@types/react@19.2.17)(react@19.2.7):
     dependencies:
@@ -3802,7 +5231,18 @@ snapshots:
 
   react@19.2.7: {}
 
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
+
   readdirp@5.0.0: {}
+
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
 
   rolldown@1.1.3:
     dependencies:
@@ -3825,9 +5265,47 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.1.3
       '@rolldown/binding-win32-x64-msvc': 1.1.3
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
+  rrweb-cssom@0.7.1: {}
+
+  rrweb-cssom@0.8.0: {}
+
+  safe-buffer@5.2.1: {}
+
+  safer-buffer@2.1.2: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
+
   scheduler@0.27.0: {}
 
   semver@6.3.1: {}
+
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.3.0
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   seroval-plugins@1.5.4(seroval@1.5.4):
     dependencies:
@@ -3835,11 +5313,52 @@ snapshots:
 
   seroval@1.5.4: {}
 
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+
+  setprototypeof@1.2.0: {}
+
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
+  siginfo@2.0.0: {}
 
   socket.io-adapter@2.5.8:
     dependencies:
@@ -3884,16 +5403,88 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  stackback@0.0.2: {}
+
+  statuses@2.0.2: {}
+
+  std-env@4.2.0: {}
+
+  streamsearch@1.1.0: {}
+
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
+
+  strtok3@10.3.5:
+    dependencies:
+      '@tokenizer/token': 0.3.0
+
+  superagent@10.3.0:
+    dependencies:
+      component-emitter: 1.3.1
+      cookiejar: 2.1.4
+      debug: 4.4.3
+      fast-safe-stringify: 2.1.1
+      form-data: 4.0.6
+      formidable: 3.5.4
+      methods: 1.1.2
+      mime: 2.6.0
+      qs: 6.15.3
+    transitivePeerDependencies:
+      - supports-color
+
+  supertest@7.2.2:
+    dependencies:
+      cookie-signature: 1.2.2
+      methods: 1.1.2
+      superagent: 10.3.0
+    transitivePeerDependencies:
+      - supports-color
+
+  symbol-tree@3.2.4: {}
+
   tailwind-merge@3.6.0: {}
 
   tailwindcss@4.3.1: {}
 
   tapable@2.3.3: {}
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.3.0: {}
+
   tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinyrainbow@3.1.1: {}
+
+  tldts-core@6.1.86: {}
+
+  tldts@6.1.86:
+    dependencies:
+      tldts-core: 6.1.86
+
+  toidentifier@1.0.1: {}
+
+  token-types@6.1.2:
+    dependencies:
+      '@borewit/text-codec': 0.2.2
+      '@tokenizer/token': 0.3.0
+      ieee754: 1.2.1
+
+  tough-cookie@5.1.2:
+    dependencies:
+      tldts: 6.1.86
+
+  tr46@5.1.1:
+    dependencies:
+      punycode: 2.3.1
 
   tslib@2.8.1: {}
 
@@ -3909,9 +5500,26 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
+  type-is@1.6.18:
+    dependencies:
+      media-typer: 0.3.0
+      mime-types: 2.1.35
+
+  type-is@2.1.0:
+    dependencies:
+      content-type: 2.1.0
+      media-typer: 1.1.1
+      mime-types: 3.0.2
+
+  typedarray@0.0.6: {}
+
   typescript@6.0.3: {}
 
+  uint8array-extras@1.5.0: {}
+
   undici-types@8.3.0: {}
+
+  unpipe@1.0.0: {}
 
   unplugin@3.2.0(esbuild@0.28.1)(rolldown@1.1.3)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)):
     dependencies:
@@ -3957,6 +5565,8 @@ snapshots:
     dependencies:
       react: 19.2.7
 
+  util-deprecate@1.0.2: {}
+
   uuid@14.0.1: {}
 
   vary@1.1.2: {}
@@ -3975,17 +5585,73 @@ snapshots:
       jiti: 2.7.0
       tsx: 4.22.4
 
+  vitest@4.1.11(@types/node@26.0.1)(jsdom@25.0.1)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)):
+    dependencies:
+      '@vitest/expect': 4.1.11
+      '@vitest/mocker': 4.1.11(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))
+      '@vitest/pretty-format': 4.1.11
+      '@vitest/runner': 4.1.11
+      '@vitest/snapshot': 4.1.11
+      '@vitest/spy': 4.1.11
+      '@vitest/utils': 4.1.11
+      es-module-lexer: 2.3.2
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.4
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.3.0
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.1
+      vite: 8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 26.0.1
+      jsdom: 25.0.1
+    transitivePeerDependencies:
+      - msw
+
   void-elements@3.1.0: {}
 
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
+  webidl-conversions@7.0.0: {}
+
   webpack-virtual-modules@0.6.2: {}
+
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
+
+  whatwg-url@14.2.0:
+    dependencies:
+      tr46: 5.1.1
+      webidl-conversions: 7.0.0
 
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
 
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
   word-wrap@1.2.5: {}
 
+  wrappy@1.0.2: {}
+
   ws@8.21.0: {}
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   xmlhttprequest-ssl@2.1.2: {}
 


### PR DESCRIPTION
Closes #62

## Summary

Let quiz creators upload media files directly in the editor instead of
hosting them elsewhere and pasting a URL, and reuse the same file across
several questions.

## Addressing the concern from the issue

In #62 you noted that local uploads would require adding an HTTP server with
a file hosting API — more involved than just serving static assets — and
could be an opportunity to move some WebSocket logic to HTTP endpoints.

This PR takes that route: it introduces a small HTTP layer in the socket
package (upload endpoint + media serving) alongside the existing WebSocket
server, rather than treating media as static assets. It's intentionally
scoped to the media use case, so it stays a reviewable first step in that
direction rather than a broad migration. Happy to adjust the shape (routes,
where the HTTP server lives, etc.) to match how you'd like to take it further.

## What it does

- **Upload from the editor**: images and audio can be uploaded per question.
  Video stays external-URL only (no video upload).
- **Reuse across questions**: uploaded files are listed in a picker so the
  same media can be attached to several questions without re-uploading.
- **Still supports URLs**: a media can be either an uploaded file (served
  under `/media/`) or an external URL, so existing quizzes keep working.
- Uploaded media is served with HTTP Range support (proper seeking for audio).

## Notes

- The server derives the media type from the file's magic bytes at upload
  time (single source of truth for MIME → extension → type) rather than
  trusting the URL/extension.
- Uploads are scoped per client id.

## Tests

- `pnpm install --frozen-lockfile`, `pnpm format`, `pnpm lint` — all green
  (matches CI).
- `pnpm build` and unit tests pass locally.

## Screenshots

<img width="2864" height="1886" alt="new-upload-file" src="https://github.com/user-attachments/assets/de747471-2e49-4dce-a202-2a939d6b0d9d" />

<img width="2864" height="1888" alt="new-modal-media-url" src="https://github.com/user-attachments/assets/835beaab-c733-4024-8743-a4ae183c04f0" />

<img width="2864" height="1888" alt="new-file-librairy" src="https://github.com/user-attachments/assets/2b9b154d-5dee-4df0-ac7c-9aa26de12e6a" />
