### PR TITLE
feat: apply branding background app-wide, not just in-game

### DIFF
--- a/docs/branding.md
+++ b/docs/branding.md
@@ -27,4 +27,4 @@ All fields are optional: anything you omit keeps its default value.
 - `colors`: CSS color tokens (at least `primary` and `secondary`)
 - `answerColors`: up to 4 answer-button colors
 - `font`: a font family + an optional stylesheet URL (e.g. Google Fonts)
-- `logo` / `favicon` / `background`: drop the files in `config/branding/` and reference them here
+- `logo` / `favicon` / `background`: drop the files in `config/branding/` and reference them here. `background` is a full-screen image applied app-wide (landing, manager and in-game screens).

--- a/packages/web/src/components/Background.tsx
+++ b/packages/web/src/components/Background.tsx
@@ -1,5 +1,6 @@
 import defaultLogo from "@razzia/web/assets/logo.svg"
 import { getBranding, imageFallback } from "@razzia/web/branding"
+import BackgroundImage from "@razzia/web/components/BackgroundImage"
 import GithubIcon from "@razzia/web/components/GithubIcon"
 import type { PropsWithChildren } from "react"
 
@@ -7,12 +8,19 @@ const Background = ({ children }: PropsWithChildren) => {
   const branding = getBranding()
   const logo = branding?.logo ?? defaultLogo
   const appName = branding?.appName ?? "Razzia"
+  const background = branding?.background
 
   return (
-    <section className="relative flex min-h-dvh flex-col items-center justify-center">
-      <div className="absolute h-full max-h-svh w-full overflow-hidden">
-        <div className="bg-primary/15 absolute top-[-70vmin] left-[-50vmin] min-h-[120vmin] min-w-[120vmin] rotate-20 rounded-4xl" />
-        <div className="bg-primary/15 absolute right-[-10vmin] bottom-[-45vmin] min-h-[75vmin] min-w-[75vmin] rotate-20 rounded-4xl" />
+    <section className="relative isolate flex min-h-dvh flex-col items-center justify-center">
+      <div className="absolute -z-10 h-full max-h-svh w-full overflow-hidden">
+        {background ? (
+          <BackgroundImage src={background} />
+        ) : (
+          <>
+            <div className="bg-primary/15 absolute top-[-70vmin] left-[-50vmin] min-h-[120vmin] min-w-[120vmin] rotate-20 rounded-4xl" />
+            <div className="bg-primary/15 absolute right-[-10vmin] bottom-[-45vmin] min-h-[75vmin] min-w-[75vmin] rotate-20 rounded-4xl" />
+          </>
+        )}
       </div>
 
       <img

--- a/packages/web/src/components/BackgroundImage.tsx
+++ b/packages/web/src/components/BackgroundImage.tsx
@@ -1,0 +1,13 @@
+import defaultBackground from "@razzia/web/assets/background.png"
+import { imageFallback } from "@razzia/web/branding"
+
+const BackgroundImage = ({ src }: { src: string }) => (
+  <img
+    className="pointer-events-none h-full w-full object-cover select-none"
+    src={src}
+    onError={imageFallback(defaultBackground)}
+    alt="background"
+  />
+)
+
+export default BackgroundImage

--- a/packages/web/src/components/GameBackground.tsx
+++ b/packages/web/src/components/GameBackground.tsx
@@ -1,17 +1,13 @@
 import defaultBackground from "@razzia/web/assets/background.png"
-import { getBranding, imageFallback } from "@razzia/web/branding"
+import { getBranding } from "@razzia/web/branding"
+import BackgroundImage from "@razzia/web/components/BackgroundImage"
 
 const GameBackground = () => {
   const background = getBranding()?.background ?? defaultBackground
 
   return (
     <div className="fixed top-0 left-0 h-full w-full">
-      <img
-        className="pointer-events-none h-full w-full object-cover select-none"
-        src={background}
-        onError={imageFallback(defaultBackground)}
-        alt="background"
-      />
+      <BackgroundImage src={background} />
     </div>
   )
 }


### PR DESCRIPTION
## Summary

Apply the custom branding background across the whole app, not only during a
game. Previously the branding background only showed up in-game; every other
screen (home, join, editor, etc.) fell back to the default background.

## What it does

- Renders the branding background at the app shell level so it's consistent
  on every screen.
- Extracts a shared `BackgroundImage` component so the in-game and app-wide
  backgrounds use the same rendering path.
- Fixes layering so the background sits behind the content without hiding the
  logo/theme switcher or shrinking the card: `<section relative isolate>`
  with the background in a `<div absolute -z-10>`, no extra wrapper around the
  content.

## Tests

- `pnpm install --frozen-lockfile`, `pnpm format`, `pnpm lint` — all green
  (matches CI).
- `pnpm build` passes locally.